### PR TITLE
Backward compatible change in configuration using initialzers

### DIFF
--- a/lib/customerio.rb
+++ b/lib/customerio.rb
@@ -2,4 +2,19 @@ require "customerio/version"
 
 module Customerio
   autoload :Client, 'customerio/client'
+  autoload :Configuration, 'customerio/configuration'
+
+
+  class << self
+    attr_writer :configuration
+
+    def configure
+      yield(configuration)
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+  end
 end

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -9,12 +9,17 @@ module Customerio
 
 	  @@id_block = nil
 
+    # <b>DEPRECATED:</b> Please use <tt>Customerio.configure.customer_id</tt> instead.
 	  def self.id(&block)
+      warn "[DEPRECATION] setting the customer_id using Client.id is deprecated, please use Customerio.config.customer_id instead."
       @@id_block = block
 	  end
 
+    # <b>DEPRECATED:</b> Using 'Customerio.default_config' is deprecated, please use <tt>Customerio.configuration = nil</tt> instead"
 	  def self.default_config
-	  	@@id_block = nil
+      warn "[DEPRECATION] Using 'Customerio.default_config' is deprecated, please use 'Customerio.configuration = nil' instead"
+      Customerio.configuration = nil
+      @@id_block = nil
 	  end
 
 	  def initialize(site_id=nil, api_key=nil)
@@ -54,7 +59,16 @@ module Customerio
 	  end
 
 	  def id(customer)
-	  	@@id_block ? @@id_block.call(customer) : customer.id
+      if !@@id_block.nil?
+        warn "[DEPRECATION] using 'Customerio::Client.id' is deprecated, you might have used Customerio::Client.id instead of Customerio.configure."
+        return @@id_block.call(customer)
+      end
+
+      if Customerio.configuration.customer_id
+        Customerio.configuration.customer_id.call(customer)
+      else
+        customer.id
+      end
 	  end
 
 	  def options

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -3,6 +3,8 @@ require 'httparty'
 module Customerio
   class Client
 	  include HTTParty
+    attr_accessor :auth
+
 	  base_uri 'https://app.customer.io'
 
 	  @@id_block = nil
@@ -15,8 +17,10 @@ module Customerio
 	  	@@id_block = nil
 	  end
 
-	  def initialize(site_id, secret_key)
-	    @auth = { :username => site_id, :password => secret_key }
+	  def initialize(site_id=nil, api_key=nil)
+      site_id = site_id || Customerio.configuration.site_id
+      api_key = api_key || Customerio.configuration.api_key
+	    @auth = { :username => site_id, :password => api_key }
 	  end
 
 	  def identify(customer, attributes = {})

--- a/lib/customerio/configuration.rb
+++ b/lib/customerio/configuration.rb
@@ -1,0 +1,6 @@
+module Customerio
+  class Configuration
+    attr_accessor :api_key, :site_id
+
+  end
+end

--- a/lib/customerio/configuration.rb
+++ b/lib/customerio/configuration.rb
@@ -1,6 +1,14 @@
 module Customerio
   class Configuration
-    attr_accessor :api_key, :site_id
+    attr_accessor :api_key, :site_id, :customer_id
+
+    def customer_id(&block)
+      if block # Block given, means setting a custom id
+        @customer_id = block
+      else #No block given is requiesting the custom id
+        @customer_id
+      end
+    end
 
   end
 end

--- a/readme.markdown
+++ b/readme.markdown
@@ -54,8 +54,10 @@ If you're using Rails, create an initializer `config/initializers/customerio.rb`
 
 By default, this gem identifies customers by just their `id`. However, a common approach is to use `production_2342` as the id attribute for the javascript snippet. You'll want to use the same format by customizing the id in `config/initializers/customerio.rb`:
 
-    Customerio::Client.id do |customer|
-      "#{Rails.env}_#{customer.id}"
+    Customerio.configuration do |config|
+      config.customer_id do |customer|
+        "#{Rails.env}_#{customer.id}"
+      end
     end
 
 ### Identify logged in customers

--- a/readme.markdown
+++ b/readme.markdown
@@ -47,7 +47,10 @@ which can be found in your [customer.io settings](https://app.customer.io/settin
 
 If you're using Rails, create an initializer `config/initializers/customerio.rb`:
 
-    $customerio = Customerio::Client.new("YOUR SITE ID", "YOUR API SECRET KEY")
+    Customerio.configuration do |config|
+      config.site_id = "YOUR SITE ID"
+      config.api_key = "YOUR API SECRET KEY"
+    end
 
 By default, this gem identifies customers by just their `id`. However, a common approach is to use `production_2342` as the id attribute for the javascript snippet. You'll want to use the same format by customizing the id in `config/initializers/customerio.rb`:
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -74,23 +74,52 @@ describe Customerio::Client do
   	end
 
     context "client has customized identities" do
-      before do
-        Customerio::Client.id do |customer|
-          "production_#{customer.id}"
+      context "using deprecated, but still supported configuration" do
+        before do
+          Customerio::Client.id do |customer|
+            "production_#{customer.id}"
+          end
+        end
+
+        after do
+          Customerio::Client.default_config
+        end
+
+        it "identifies the customer with the identification method" do
+          Customerio::Client.should_receive(:put).with("/api/v1/customers/production_5", {
+            :basic_auth => anything(),
+            :body => {
+              :id => "production_5",
+              :email => "customer@example.com",
+              :created_at => Time.now.to_i
+            }
+          })
+
+          client.identify(customer)
         end
       end
 
-      it "identifies the customer with the identification method" do
-        Customerio::Client.should_receive(:put).with("/api/v1/customers/production_5", {
-          :basic_auth => anything(),
-          :body => {
-            :id => "production_5",
-            :email => "customer@example.com",
-            :created_at => Time.now.to_i
-          }
-        })
+      context "using preferred configuration" do
+        before do
+          Customerio.configure do |config|
+            config.customer_id do |customer|
+              "production_#{customer.id}"
+            end
+          end
+        end
 
-        client.identify(customer)
+        it "identifies the customer with the identification method" do
+          Customerio::Client.should_receive(:put).with("/api/v1/customers/production_5", {
+            :basic_auth => anything(),
+            :body => {
+              :id => "production_5",
+              :email => "customer@example.com",
+              :created_at => Time.now.to_i
+            }
+          })
+
+          client.identify(customer)
+        end
       end
     end
   end
@@ -144,8 +173,10 @@ describe Customerio::Client do
 
     context "client has customized identities" do
       before do
-        Customerio::Client.id do |customer|
-          "production_#{customer.id}"
+        Customerio.configure do |config|
+          config.customer_id do |customer|
+            "production_#{customer.id}"
+          end
         end
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,6 +10,26 @@ describe Customerio::Client do
   	end
   end
 
+  describe "initialization of client" do
+
+    it "by config object" do
+      Customerio.configure do |config|
+        config.api_key = "API_KEY"
+        config.site_id = "SITE_ID"
+      end
+      client = Customerio::Client.new
+      client.auth[:username].should eql("SITE_ID")
+      client.auth[:password].should eql("API_KEY")
+    end
+
+    it "by providing site_id and api_key directly" do
+      Customerio.configuration = nil
+      client = Customerio::Client.new("SITE_ID","API_KEY")
+      client.auth[:username].should eql("SITE_ID")
+      client.auth[:password].should eql("API_KEY")
+    end
+  end
+
   describe "#identify" do
   	it "sends a PUT request to customer.io's customer API" do
   		Customerio::Client.should_receive(:put).with("/api/v1/customers/5", anything())

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Customerio::Configuration do
+
+  it "Should initialize empty configuration" do
+    lambda{Customerio::Configuration.new}.should_not raise_error
+  end
+
+  describe "Setting keys on config object" do
+    let(:config) { Customerio::Configuration.new }
+
+   it "should set api key" do
+     config.api_key = "something_non_trivial"
+     config.api_key.should eql("something_non_trivial")
+   end
+
+   it "should set site id" do
+     config.site_id = "some_random_string"
+     config.site_id.should eql("some_random_string")
+   end
+
+  end
+
+
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -19,6 +19,15 @@ describe Customerio::Configuration do
      config.site_id.should eql("some_random_string")
    end
 
+   it "should set customer_id" do
+     config.customer_id do |customer|
+       "alternate_id_#{customer.id}"
+     end
+     customer = double("customer", :id=>123)
+     config.customer_id.call(customer).should eql("alternate_id_123")
+   end
+
+
   end
 
 

--- a/spec/customerio_spec.rb
+++ b/spec/customerio_spec.rb
@@ -17,6 +17,15 @@ describe Customerio do
       Customerio.configuration.site_id.should eql("SITE_ID")
     end
 
+    it "should reset configuration" do
+      Customerio.configure do |config|
+        config.api_key = "please_remove_me"
+      end
+      Customerio.configuration.api_key.should eql("please_remove_me")
+      Customerio.configuration = nil
+      Customerio.configuration.api_key.should be_nil
+    end
+
   end
 
 end

--- a/spec/customerio_spec.rb
+++ b/spec/customerio_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Customerio do
+
+  describe "Configuring Customerio" do
+    it "should use the configuration opbject" do
+      Customerio.configuration.class.should eql(Customerio::Configuration)
+    end
+
+    it "by config object" do
+      Customerio.configure do |config|
+        config.api_key = "API_KEY"
+        config.site_id = "SITE_ID"
+      end
+
+      Customerio.configuration.api_key.should eql("API_KEY")
+      Customerio.configuration.site_id.should eql("SITE_ID")
+    end
+
+  end
+
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'fakeweb'
 FakeWeb.allow_net_connect = false
 
 RSpec.configure do |config|
-  config.before(:each) do
-    Customerio::Client.default_config
+  config.after(:each) do
+    Customerio.configuration = nil
   end
 end


### PR DESCRIPTION
In order to use CustomerIO gem in a rails project, I altered the way you can do the configuration. In the new way you can configure CustomerIO using a a configuration object instead of using a global variable (which is not common in rails land).

Example:

config/initializers/customerio.rb

      Customerio.configure do |config|
        config.api_key = "API_KEY"
        config.site_id = "SITE_ID"
      end

In the app you can then do:

      client = Customerio::Client.new

Tests, and documentation have been updated.
