### PR TITLE
Convert Time, Date, and DateTime objects to integer timestamps

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -42,13 +42,13 @@ describe Customerio::Client do
         :body => {
           :id => 5,
           :email => "customer@example.com",
-          :created_at => Time.now.to_i,
+          :created_at => 1374701292,
           :first_name => "Bob",
           :plan => "basic"
         }
       }).and_return(response)
 
-      client.identify(:id => 5, :email => "customer@example.com", :created_at => Time.now.to_i, :first_name => "Bob", :plan => "basic")
+      client.identify(:id => 5, :email => "customer@example.com", :created_at => 1374701292, :first_name => "Bob", :plan => "basic")
     end
 
     it "requires an id attribute" do


### PR DESCRIPTION
This seems like the right behaviour, since Customer.io always wants timestamps as integers.

Also includes a little change to a test that seemed like it would otherwise break if the clock ticked at the wrong time.