### PR TITLE
use client#track with json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    customerio (0.5.0)
+    customerio (0.5.1)
       httparty (>= 0.5, < 1.0)
 
 GEM
@@ -9,11 +9,11 @@ GEM
   specs:
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
-    httparty (0.10.2)
-      multi_json (~> 1.0)
+    httparty (0.13.1)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
-    multi_json (1.7.0)
-    multi_xml (0.5.3)
+    json (1.8.1)
+    multi_xml (0.5.5)
     rake (0.9.2.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -63,7 +63,12 @@ module Customerio
     def create_event(url, event_name, attributes = {})
       body = { :name => event_name, :data => attributes }
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
-      verify_response(self.class.post(url, options.merge(:body => body)))
+
+      if @json
+        verify_response(self.class.post(url, options.merge(:body => body.to_json, :headers => {'Content-Type' => 'application/json'})))
+      else
+        verify_response(self.class.post(url, options.merge(:body => body)))
+      end
     end
 
     def customer_path(id)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -93,6 +93,18 @@ describe Customerio::Client do
       client.track(5, "purchase")
   	end
 
+    it "sends JSON serialized data with a POST request to customer.io's customer API using json headers" do
+
+      client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
+      Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
+        :basic_auth=>{:username=>"SITE_ID", :password=>"API_KEY"},
+        :body=>"{\"name\":\"purchase\",\"data\":{\"type\":\"socks\",\"price\":\"13.99\"}}",
+        :headers=>{"Content-Type"=>"application/json"}
+      }).and_return(response)
+
+      client.track(5, "purchase", :type => "socks", :price => "13.99")
+    end
+
   	it "sends the event name" do
   		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
   			:basic_auth => anything(),


### PR DESCRIPTION
I've been working off of this fork for quite a while, it addressed issues with sending arrays of data to CIO which didn't serialize too well before. Other methods seemed to respect the `json` option, but not `track`, which is what this PR addresses.
