### PR TITLE
update API link

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # Customerio
 
-A ruby client for the [Customer.io](http://customer.io) [event API](https://app.customer.io/api/docs/index.html).
+A ruby client for the [Customer.io](http://customer.io) [event API](http://customer.io/docs/api/overview.html).
 
 [![Build Status](https://secure.travis-ci.org/customerio/customerio-ruby.png?branch=master)](http://travis-ci.org/customerio/customerio-ruby)
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/customerio/customerio-ruby)


### PR DESCRIPTION
I can't access https://app.customer.io/api/docs/index.html . 
Probably I think that http://customer.io/docs/api/overview.html is a right URL