### PR TITLE
Use a default timeout of 10 seconds

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -5,6 +5,7 @@ module Customerio
   class Client
     include HTTParty
     base_uri 'https://track.customer.io'
+    default_timeout 10
 
     class MissingIdAttributeError < RuntimeError; end
     class InvalidResponse < RuntimeError; end


### PR DESCRIPTION
I suggest using a sane default timeout when talking to the REST API. 