### PR TITLE
Include HTTP response in InvalidResponse exception

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -8,7 +8,14 @@ module Customerio
     default_timeout 10
 
     class MissingIdAttributeError < RuntimeError; end
-    class InvalidResponse < RuntimeError; end
+    class InvalidResponse < RuntimeError
+      attr_reader :response
+
+      def initialize(message, response)
+        @message = message
+        @response = response
+      end
+    end
 
     def initialize(site_id, secret_key, options = {})
       @auth = { :username => site_id, :password => secret_key }
@@ -89,7 +96,7 @@ module Customerio
       if response.code >= 200 && response.code < 300
         response
       else
-        raise InvalidResponse.new("Customer.io API returned an invalid response: #{response.code}")
+        raise InvalidResponse.new("Customer.io API returned an invalid response: #{response.code}", response)
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -40,6 +40,15 @@ describe Customerio::Client do
       lambda { client.identify(:id => 5) }.should raise_error(Customerio::Client::InvalidResponse)
     end
 
+    it "includes the HTTP response with raised errors" do
+      response = double("Response", :code => 500, :body => "whatever")
+      Customerio::Client.should_receive(:put).and_return(response)
+      lambda { client.identify(:id => 5) }.should raise_error {|error|
+        error.should be_a Customerio::Client::InvalidResponse
+        error.response.should eq response
+      }
+    end
+
     it "uses the site_id and api key for basic auth" do
       Customerio::Client.should_receive(:put).with("/api/v1/customers/5", {
         :basic_auth => { :username => "SITE_ID", :password => "API_KEY" },


### PR DESCRIPTION
This allows users to base their exception handling on the full HTTP response, rather than parsing the HTTP status code out of the exception message.

Fixes #33