### PR TITLE
Fix anonymous tracking

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -34,6 +34,7 @@ module Customerio
     end
 
     def track(*args)
+      args.compact!
       attributes = extract_attributes(args)
 
       if args.length == 1

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -233,6 +233,18 @@ describe Customerio::Client do
         client.track("purchase", :type => "socks", :price => "13.99")
       end
 
+      it "sends an anonymous even when nil attributes are passed" do
+        Customerio::Client.should_receive(:post).with("/api/v1/events", {
+          :basic_auth => anything(),
+          :body => {
+            :name => "purchase",
+            :data => { :price => "20.99" }
+          }
+        }).and_return(response)
+
+        client.track("purchase", nil, :price => "13.99")
+      end
+
       it "allows sending of a timestamp" do
         Customerio::Client.should_receive(:post).with("/api/v1/events", {
           :basic_auth => anything(),


### PR DESCRIPTION
Fixes #29, where sending nil attributes caused anonymous events to be tracked as non-anonymous events. This ensures that the argument counting code distinguishes between both event types correctly.