### PR TITLE
Add anonymous track function

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -49,6 +49,10 @@ module Customerio
       end
     end
 
+    def anonymous_track(event_name, attributes = {})
+      create_anonymous_event(event_name, attributes)
+    end
+
     private
 
     def create_or_update(attributes = {})


### PR DESCRIPTION
In cases where `client.track` is called with three arguments (`customer_id`, `event_name`, `attributes`), but the first is null (to indicate an anonymous event), the `client.track` function tracks a event associated with a customer, rather than an anonymous event. This PR adds an additional tracking function, `anonymous_track`, which takes only two arguments and produces an anonymous event, and is intended as a response to the suggestions mentioned by @alisdair in #35. 