### PR TITLE
Use webmock to improve test coverage 

### DIFF
--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rspec')
-  gem.add_development_dependency('fakeweb')
+  gem.add_development_dependency('webmock')
 end

--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('webmock')
   gem.add_development_dependency('addressable', '~> 2.3.6')
+  gem.add_development_dependency('json')
 end

--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('webmock')
+  gem.add_development_dependency('addressable', '~> 2.3.6')
 end

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -62,7 +62,7 @@ module Customerio
       if @json
         verify_response(self.class.put(url, options.merge(:body => MultiJson.dump(attributes), :headers => {'Content-Type' => 'application/json'})))
       else
-        verify_response(self.class.put(url, options.merge(:body => attributes)))
+        verify_response(self.class.put(url, options.merge(:body => attributes, :headers => {'Content-Type' => 'application/x-www-form-urlencoded'})))
       end
     end
 
@@ -80,7 +80,7 @@ module Customerio
       if @json
         verify_response(self.class.post(url, options.merge(:body => MultiJson.dump(body), :headers => {'Content-Type' => 'application/json'})))
       else
-        verify_response(self.class.post(url, options.merge(:body => body)))
+        verify_response(self.class.post(url, options.merge(:body => body, :headers => {'Content-Type' => 'application/x-www-form-urlencoded'})))
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -32,7 +32,7 @@ describe Customerio::Client do
       client = Customerio::Client.new("SITE_ID", "API_KEY", :json => false)
 
       stub_request(:put, api_uri('/api/v1/customers/5')).
-        with(:body => 'id=5&name=Bob').
+        with(:body => { :id => "5", :name => "Bob" }).
         to_return(:status => 200, :body => "", :headers => {})
 
       client.identify(body)
@@ -89,11 +89,22 @@ describe Customerio::Client do
     it "sends along all attributes" do
       time = Time.now.to_i
 
-      stub_request(:put, api_uri('/api/v1/customers/5')).
-        with(:body => "id=5&email=customer%40example.com&created_at=#{time}&first_name=Bob&plan=basic").
-        to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:put, api_uri('/api/v1/customers/5')).with(
+        :body => {
+          :id => "5",
+          :email => "customer@example.com",
+          :created_at => time.to_s,
+          :first_name => "Bob",
+          :plan => "basic"
+        }).to_return(:status => 200, :body => "", :headers => {})
 
-      client.identify(:id => 5, :email => "customer@example.com", :created_at => time, :first_name => "Bob", :plan => "basic")
+      client.identify({
+        :id => 5,
+        :email => "customer@example.com",
+        :created_at => time,
+        :first_name => "Bob",
+        :plan => "basic"
+      })
     end
 
     it "requires an id attribute" do
@@ -139,7 +150,13 @@ describe Customerio::Client do
 
     it "sends any optional event attributes" do
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
-         with(:body => "name=purchase&data[type]=socks&data[price]=13.99").
+         with(:body => {
+          :name => "purchase",
+          :data => {
+            :type => "socks",
+            :price => "13.99"
+          }
+        }).
         to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99")
@@ -160,7 +177,15 @@ describe Customerio::Client do
 
     it "allows sending of a timestamp" do
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234&timestamp=1561231234").
+        with(:body => {
+          :name => "purchase",
+          :data => {
+            :type => "socks",
+            :price => "13.99",
+            :timestamp => "1561231234"
+          },
+          :timestamp => "1561231234"
+        }).
         to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234)
@@ -168,7 +193,14 @@ describe Customerio::Client do
 
     it "doesn't send timestamp if timestamp is in milliseconds" do
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234000").
+        with(:body => {
+          :name => "purchase",
+          :data => {
+            :type => "socks",
+            :price => "13.99",
+            :timestamp => "1561231234000"
+          }
+        }).
         to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234000)
@@ -178,15 +210,30 @@ describe Customerio::Client do
       date = Time.now
 
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(:body => /^name=purchase&data\[type\]=socks&data\[price\]=13\.99&data\[timestamp\]=[^&]+$/).
+        with(:body => {
+          :name => "purchase",
+          :data => {
+            :type => "socks",
+            :price => "13.99",
+            :timestamp => Time.now.to_s
+          }
+        }).
         to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => date)
     end
 
-    it "doesn't send timestamp if timestamp isn't a integer" do
+    it "doesn't send timestamp if timestamp isn't an integer" do
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=Hello%20world").
+        with(:body => {
+          :name => "purchase",
+          :data => {
+            :type => "socks",
+            :price => "13.99",
+            :timestamp => "Hello world"
+          }
+        }).
+
         to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => "Hello world")
@@ -203,7 +250,13 @@ describe Customerio::Client do
 
       it "sends any optional event attributes" do
         stub_request(:post, api_uri('/api/v1/events')).
-          with(:body => "name=purchase&data[type]=socks&data[price]=13.99").
+          with(:body => {
+            :name => "purchase",
+            :data => {
+              :type => "socks",
+              :price => "13.99"
+            }
+          }).
           to_return(:status => 200, :body => "", :headers => {})
 
         client.track("purchase", :type => "socks", :price => "13.99")
@@ -211,7 +264,15 @@ describe Customerio::Client do
 
       it "allows sending of a timestamp" do
         stub_request(:post, api_uri('/api/v1/events')).
-          with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234&timestamp=1561231234").
+          with(:body => {
+            :name => "purchase",
+            :data => {
+              :type => "socks",
+              :price => "13.99",
+              :timestamp => "1561231234"
+            },
+            :timestamp => "1561231234"
+          }).
           to_return(:status => 200, :body => "", :headers => {})
 
         client.track("purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234)
@@ -238,7 +299,14 @@ describe Customerio::Client do
 
     it "sends any optional event attributes" do
       stub_request(:post, api_uri('/api/v1/events')).
-        with(:body => "name=purchase&data[type]=socks&data[price]=27.99").
+          with(:body => {
+            :name => "purchase",
+            :data => {
+              :type => "socks",
+              :price => "27.99"
+            },
+          }).
+
         to_return(:status => 200, :body => "", :headers => {})
 
       client.anonymous_track("purchase", :type => "socks", :price => "27.99")
@@ -246,7 +314,16 @@ describe Customerio::Client do
 
     it "allows sending of a timestamp" do
       stub_request(:post, api_uri('/api/v1/events')).
-        with(:body => "name=purchase&data[type]=socks&data[price]=27.99&data[timestamp]=1561235678&timestamp=1561235678").
+          with(:body => {
+            :name => "purchase",
+            :data => {
+              :type => "socks",
+              :price => "27.99",
+              :timestamp => "1561235678"
+            },
+            :timestamp => "1561235678"
+          }).
+
         to_return(:status => 200, :body => "", :headers => {})
 
       client.anonymous_track("purchase", :type => "socks", :price => "27.99", :timestamp => 1561235678)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 require 'multi_json'
 
+
 describe Customerio::Client do
   let(:client)   { Customerio::Client.new("SITE_ID", "API_KEY", :json => false) }
   let(:response) { double("Response", :code => 200) }
 
-  before do
-    # Dont call out to customer.io
-    Customerio::Client.stub(:post).and_return(response)
-    Customerio::Client.stub(:put).and_return(response)
+  def api_uri(path)
+    "https://SITE_ID:API_KEY@track.customer.io#{path}"
+  end
+
+  def json(data)
+    MultiJson.dump(data)
   end
 
   describe "json option" do
@@ -17,90 +20,80 @@ describe Customerio::Client do
     it "uses json by default" do
       client = Customerio::Client.new("SITE_ID", "API_KEY")
 
-      json = MultiJson.dump(body)
-      Customerio::Client.should_receive(:put).with(
-        "/api/v1/customers/5",
-        {
-          :basic_auth=>{:username=>"SITE_ID", :password=>"API_KEY"},
-          :body=>json,
-          :headers=>{"Content-Type"=>"application/json"}
-        }).and_return(response)
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => json(body),
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
       client.identify(body)
     end
 
     it "allows disabling json" do
       client = Customerio::Client.new("SITE_ID", "API_KEY", :json => false)
 
-      Customerio::Client.should_receive(:put).with(
-        "/api/v1/customers/5",
-        {
-          :basic_auth=>{:username=>"SITE_ID", :password=>"API_KEY"},
-          :body=>body
-        }).and_return(response)
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => 'id=5&name=Bob').
+        to_return(:status => 200, :body => "", :headers => {})
+
       client.identify(body)
     end
   end
 
   describe ".base_uri" do
-  	it "should be set to customer.io's api" do
-  		Customerio::Client.base_uri.should == "https://track.customer.io"
-  	end
+    it "should be set to customer.io's api" do
+      Customerio::Client.base_uri.should == "https://track.customer.io"
+    end
   end
 
   describe "#identify" do
     it "sends a PUT request to customer.io's customer API" do
-      Customerio::Client.should_receive(:put).with("/api/v1/customers/5", anything()).and_return(response)
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+         with(:body => "id=5").
+         to_return(:status => 200, :body => "", :headers => {})
+
       client.identify(:id => 5)
     end
 
     it "sends a PUT request to customer.io's customer API using json headers" do
       client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
       body = { :id => 5, :name => "Bob" }
-      json = MultiJson.dump(body)
-      Customerio::Client.should_receive(:put).with(
-        "/api/v1/customers/5",
-        {:basic_auth=>{:username=>"SITE_ID", :password=>"API_KEY"},
-          :body=>json,
-          :headers=>{"Content-Type"=>"application/json"}}).and_return(response)
+
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => json(body),
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
       client.identify(body)
     end
 
     it "raises an error if PUT doesn't return a 2xx response code" do
-      Customerio::Client.should_receive(:put).and_return(double("Response", :code => 500))
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => "id=5").
+        to_return(:status => 500, :body => "", :headers => {})
+
       lambda { client.identify(:id => 5) }.should raise_error(Customerio::Client::InvalidResponse)
     end
 
     it "includes the HTTP response with raised errors" do
-      response = double("Response", :code => 500, :body => "whatever")
-      Customerio::Client.should_receive(:put).and_return(response)
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => "id=5").
+        to_return(:status => 500, :body => "whatever", :headers => {})
+
       lambda { client.identify(:id => 5) }.should raise_error {|error|
         error.should be_a Customerio::Client::InvalidResponse
-        error.response.should eq response
+        error.response.code.should eq 500
+        error.response.body.should eq "whatever"
       }
     end
 
-    it "uses the site_id and api key for basic auth" do
-      Customerio::Client.should_receive(:put).with("/api/v1/customers/5", {
-        :basic_auth => { :username => "SITE_ID", :password => "API_KEY" },
-        :body => anything()
-      }).and_return(response)
-
-      client.identify(:id => 5)
-    end
-
     it "sends along all attributes" do
-      Customerio::Client.should_receive(:put).with("/api/v1/customers/5", {
-        :basic_auth => anything(),
-        :body => {
-          :id => 5,
-          :email => "customer@example.com",
-          :created_at => Time.now.to_i,
-          :first_name => "Bob",
-          :plan => "basic"
-        }
-      }).and_return(response)
+      time = Time.now.to_i
 
-      client.identify(:id => 5, :email => "customer@example.com", :created_at => Time.now.to_i, :first_name => "Bob", :plan => "basic")
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => "id=5&email=customer%40example.com&created_at=#{time}&first_name=Bob&plan=basic").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      client.identify(:id => 5, :email => "customer@example.com", :created_at => time, :first_name => "Bob", :plan => "basic")
     end
 
     it "requires an id attribute" do
@@ -108,6 +101,10 @@ describe Customerio::Client do
     end
 
     it 'should not raise errors when attribute keys are strings' do
+      stub_request(:put, api_uri('/api/v1/customers/5')).
+        with(:body => "id=5").
+        to_return(:status => 200, :body => "", :headers => {})
+
       attributes = { "id" => 5 }
 
       lambda { client.identify(attributes) }.should_not raise_error()
@@ -115,88 +112,64 @@ describe Customerio::Client do
   end
 
   describe "#delete" do
-  	it "sends a DELETE request to the customer.io's event API" do
-  		Customerio::Client.should_receive(:delete).with("/api/v1/customers/5", anything()).and_return(response)
+    it "sends a DELETE request to the customer.io's event API" do
+      stub_request(:delete, api_uri('/api/v1/customers/5')).
+        to_return(:status => 200, :body => "", :headers => {})
+
       client.delete(5)
-  	end
+    end
   end
 
   describe "#track" do
-  	it "sends a POST request to the customer.io's event API" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", anything()).and_return(response)
-      client.track(5, "purchase")
-  	end
-
     it "raises an error if POST doesn't return a 2xx response code" do
-      Customerio::Client.should_receive(:post).and_return(double("Response", :code => 500))
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => "name=purchase").
+        to_return(:status => 500, :body => "", :headers => {})
+
       lambda { client.track(5, "purchase") }.should raise_error(Customerio::Client::InvalidResponse)
     end
 
-  	it "uses the site_id and api key for basic auth" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => { :username => "SITE_ID", :password => "API_KEY" },
-  			:body => anything()
-  		})
+    it "uses the site_id and api key for basic auth and sends the event name" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => "name=purchase").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase")
-  	end
+    end
 
-  	it "sends the event name" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => { :name => "purchase", :data => {} }
-  		}).and_return(response)
+    it "sends any optional event attributes" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+         with(:body => "name=purchase&data[type]=socks&data[price]=13.99").
+        to_return(:status => 200, :body => "", :headers => {})
 
-      client.track(5, "purchase")
-  	end
-
-  	it "sends any optional event attributes" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => {
-  				:name => "purchase",
-  			  :data => { :type => "socks", :price => "13.99" }
-  			}
-  		}).and_return(response)
-
-      client.track(5, "purchase", :type => "socks", :price => "13.99")
-  	end
-
-    it "sends a POST request as json using json headers" do
-      client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
-  		Customerio::Client.should_receive(:post).with(
-        "/api/v1/customers/5/events", {
-          :basic_auth => anything(),
-          :body => MultiJson.dump({
-            :name => "purchase",
-            :data => { :type => "socks", :price => "13.99" }
-          }),
-        :headers=>{"Content-Type"=>"application/json"}}).and_return(response)
       client.track(5, "purchase", :type => "socks", :price => "13.99")
     end
 
+    it "sends a POST request as json using json headers" do
+      client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
+      data = { :type => "socks", :price => "13.99" }
+      body = { :name => "purchase", :data => data }
 
-  	it "allows sending of a timestamp" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => {
-  				:name => "purchase",
-  			  :data => { :type => "socks", :price => "13.99", :timestamp => 1561231234 },
-          :timestamp => 1561231234
-  			}
-  		}).and_return(response)
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => json(body),
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
+      client.track(5, "purchase", data)
+    end
+
+    it "allows sending of a timestamp" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234&timestamp=1561231234").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234)
-  	end
+    end
 
     it "doesn't send timestamp if timestamp is in milliseconds" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => {
-  				:name => "purchase",
-  			  :data => { :type => "socks", :price => "13.99", :timestamp => 1561231234000 }
-  			}
-  		}).and_return(response)
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234000").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234000)
     end
@@ -204,74 +177,42 @@ describe Customerio::Client do
     it "doesn't send timestamp if timestamp is a date" do
       date = Time.now
 
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => {
-  				:name => "purchase",
-  			  :data => { :type => "socks", :price => "13.99", :timestamp => date }
-  			}
-  		}).and_return(response)
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => /^name=purchase&data\[type\]=socks&data\[price\]=13\.99&data\[timestamp\]=[^&]+$/).
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => date)
     end
 
     it "doesn't send timestamp if timestamp isn't a integer" do
-  		Customerio::Client.should_receive(:post).with("/api/v1/customers/5/events", {
-  			:basic_auth => anything(),
-  			:body => {
-  				:name => "purchase",
-  			  :data => { :type => "socks", :price => "13.99", :timestamp => "Hello world" }
-  			}
-  		}).and_return(response)
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=Hello%20world").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => "Hello world")
     end
 
     context "tracking an anonymous event" do
       it "sends a POST request to the customer.io's anonymous event API" do
-        Customerio::Client.should_receive(:post).with("/api/v1/events", anything()).and_return(response)
-        client.track("purchase")
-      end
-
-      it "uses the site_id and api key for basic auth" do
-        Customerio::Client.should_receive(:post).with("/api/v1/events", {
-          :basic_auth => { :username => "SITE_ID", :password => "API_KEY" },
-          :body => anything()
-        }).and_return(response)
-
-        client.track("purchase")
-      end
-
-      it "sends the event name" do
-        Customerio::Client.should_receive(:post).with("/api/v1/events", {
-          :basic_auth => anything(),
-          :body => { :name => "purchase", :data => {} }
-        }).and_return(response)
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(:body => "name=purchase").
+          to_return(:status => 200, :body => "", :headers => {})
 
         client.track("purchase")
       end
 
       it "sends any optional event attributes" do
-        Customerio::Client.should_receive(:post).with("/api/v1/events", {
-          :basic_auth => anything(),
-          :body => {
-            :name => "purchase",
-            :data => { :type => "socks", :price => "13.99" }
-          }
-        }).and_return(response)
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(:body => "name=purchase&data[type]=socks&data[price]=13.99").
+          to_return(:status => 200, :body => "", :headers => {})
 
         client.track("purchase", :type => "socks", :price => "13.99")
       end
 
       it "allows sending of a timestamp" do
-        Customerio::Client.should_receive(:post).with("/api/v1/events", {
-          :basic_auth => anything(),
-          :body => {
-            :name => "purchase",
-  			    :data => { :type => "socks", :price => "13.99", :timestamp => 1561231234 },
-            :timestamp => 1561231234
-          }
-        }).and_return(response)
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(:body => "name=purchase&data[type]=socks&data[price]=13.99&data[timestamp]=1561231234&timestamp=1561231234").
+          to_return(:status => 200, :body => "", :headers => {})
 
         client.track("purchase", :type => "socks", :price => "13.99", :timestamp => 1561231234)
       end
@@ -279,55 +220,34 @@ describe Customerio::Client do
   end
 
   describe "#anonymous_track" do
-    it "sends a POST request to the customer.io event API" do
-      Customerio::Client.should_receive(:post).with("/api/v1/events", anything()).and_return(response)
-      client.anonymous_track("purchase")
-    end
-
     it "raises an error if POST doesn't return a 2xx response code" do
-      Customerio::Client.should_receive(:post).and_return(double("Response", :code => 500))
+      stub_request(:post, api_uri('/api/v1/events')).
+        with(:body => "name=purchase").
+        to_return(:status => 500, :body => "", :headers => {})
+
       lambda { client.anonymous_track("purchase") }.should raise_error(Customerio::Client::InvalidResponse)
     end
 
-    it "uses the site_id and api key for basic auth" do
-      Customerio::Client.should_receive(:post).with("/api/v1/events", {
-        :basic_auth => { :username => "SITE_ID", :password => "API_KEY" },
-        :body => anything()
-      })
-
-      client.anonymous_track("purchase")
-    end
-
-    it "sends the event name" do
-      Customerio::Client.should_receive(:post).with("/api/v1/events", {
-        :basic_auth => anything(),
-        :body => { :name => "purchase", :data => {} }
-      }).and_return(response)
+    it "uses the site_id and api key for basic auth and sends the event name" do
+      stub_request(:post, api_uri('/api/v1/events')).
+        with(:body => "name=purchase").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.anonymous_track("purchase")
     end
 
     it "sends any optional event attributes" do
-      Customerio::Client.should_receive(:post).with("/api/v1/events", {
-        :basic_auth => anything(),
-        :body => {
-          :name => "purchase",
-          :data => { :type => "socks", :price => "27.99" }
-        }
-      }).and_return(response)
+      stub_request(:post, api_uri('/api/v1/events')).
+        with(:body => "name=purchase&data[type]=socks&data[price]=27.99").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.anonymous_track("purchase", :type => "socks", :price => "27.99")
     end
 
     it "allows sending of a timestamp" do
-      Customerio::Client.should_receive(:post).with("/api/v1/events", {
-        :basic_auth => anything(),
-        :body => {
-          :name => "purchase",
-          :data => { :type => "socks", :price => "27.99", :timestamp => 1561235678 },
-          :timestamp => 1561235678
-        }
-      }).and_return(response)
+      stub_request(:post, api_uri('/api/v1/events')).
+        with(:body => "name=purchase&data[type]=socks&data[price]=27.99&data[timestamp]=1561235678&timestamp=1561235678").
+        to_return(:status => 200, :body => "", :headers => {})
 
       client.anonymous_track("purchase", :type => "socks", :price => "27.99", :timestamp => 1561235678)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,13 @@ require 'rubygems'
 require 'bundler/setup'
 
 require 'customerio'
-require 'fakeweb'
+require 'webmock'
 
-FakeWeb.allow_net_connect = false
+WebMock.disable_net_connect!
 
 require 'rspec'
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :should }
   config.mock_with(:rspec) { |c| c.syntax = :should }


### PR DESCRIPTION
Instead of mocking at the HTTParty interface, use webmock to stub out HTTP requests directly.

Two motivations:

- We can be more certain about what is going out to our API servers, since we're asserting against HTTP requests and responses;

- We can change our underlying HTTP library and retain the test coverage at the HTTP level.

The only change to the client itself is adding `Content-Type: application/x-www-form-urlencoded` for non-JSON requests. I believe this should have no effect on our API servers, but is required for webmock to auto-decode the request body.