### PR TITLE
fix: show InvalidResponse error message in exception output

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -13,7 +13,7 @@ module Customerio
       attr_reader :response
 
       def initialize(message, response)
-        @message = message
+        super(message)
         @response = response
       end
     end


### PR DESCRIPTION
Fixes https://github.com/customerio/customerio-ruby/issues/50