### PR TITLE
Add support for manual segments

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -88,7 +88,35 @@ module Customerio
       verify_response(request(:delete, device_id_path(customer_id, device_id)))
     end
 
+    def add_to_segment(segment_id, customer_ids)
+      raise ParamError.new("segment_id must be an integer") unless segment_id.is_a? Integer
+      raise ParamError.new("customer_ids must be a list of values") unless customer_ids.is_a? Array
+      raise ParamError.new("customer_ids cannot have more than 1000 items") unless customer_ids.length <= 1000
+
+      verify_response(request(:post, add_to_segment_path(segment_id), {
+        :ids => customer_ids,
+      }))
+    end
+
+    def remove_from_segment(segment_id, customer_ids)
+      raise ParamError.new("segment_id must be an integer") unless segment_id.is_a? Integer
+      raise ParamError.new("customer_ids must be a list of values") unless customer_ids.is_a? Array
+      raise ParamError.new("customer_ids cannot have more than 1000 items") unless customer_ids.length <= 1000
+      
+      verify_response(request(:post, remove_from_segment_path(segment_id), {
+        :ids => customer_ids,
+      }))
+    end
+
     private
+
+    def add_to_segment_path(segment_id)
+      "/api/v1/segments/#{segment_id}/add_customers"
+    end
+
+    def remove_from_segment_path(segment_id)
+      "/api/v1/segments/#{segment_id}/remove_customers"
+    end
 
     def device_path(customer_id)
       "/api/v1/customers/#{customer_id}/devices"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -436,4 +436,47 @@ describe Customerio::Client do
        lambda { client.delete_device(5, nil) }.should raise_error(Customerio::Client::ParamError)
     end
   end
+
+  describe "#manual_segments" do
+    it "allows adding customers to a manual segment" do
+      stub_request(:post, api_uri('/api/v1/segments/1/add_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      client.add_to_segment(1, ["customer1", "customer2", "customer3"])
+    end
+    it "requires a valid segment id when adding customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/add_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.add_to_segment("not_valid", ["customer1", "customer2", "customer3"]).should raise_error(Customerio::Client::ParamError) }
+    end
+    it "requires a valid customer list when adding customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/add_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.add_to_segment(1, "not_valid").should raise_error(Customerio::Client::ParamError) }
+    end
+    it "validates the size of the customer list when adding customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/add_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.add_to_segment(1, [1..1001]).should raise_error(Customerio::Client::ParamError) }
+    end
+    it "allows removing customers from a manual segment" do
+      stub_request(:post, api_uri('/api/v1/segments/1/remove_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      client.remove_from_segment(1, ["customer1", "customer2", "customer3"])
+    end
+    it "requires a valid segment id when removing customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/remove_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.remove_from_segment("not_valid", ["customer1", "customer2", "customer3"]).should raise_error(Customerio::Client::ParamError) }
+    end
+    it "requires a valid customer list when removing customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/remove_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.remove_from_segment(1, "not_valid").should raise_error(Customerio::Client::ParamError) }
+    end
+    it "validates the size of the customer list when removing customers" do
+      stub_request(:post, api_uri('/api/v1/segments/1/remove_customers')).to_return(:status => 200, :body => "", :headers => {})
+
+      lambda { client.remove_from_segment(1, [1..1001]).should raise_error(Customerio::Client::ParamError) }
+    end
+  end
 end


### PR DESCRIPTION
Adds support for upcoming `/api/v1/segments/:id/add_customers` and `/api/v1/segments/:id/remove_customers` APIs