### PR TITLE
gemspec: Set the license attribute to MIT

### DIFF
--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = "A ruby client for the Customer.io event API."
   gem.summary       = "A ruby client for the Customer.io event API."
   gem.homepage      = "http://customer.io"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hi, this is just a simple change to help `bundle licenses` detect which license the gem is using. 

Related docs: 
* https://guides.rubygems.org/specification-reference/#license=