### PR TITLE
Use CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,97 @@
+version: 2.1
+
+commands:
+  - rubytest:
+      steps:
+        # Which version of bundler?
+        - run:
+            name: Which bundler?
+            command: bundle -v
+
+        # Restore bundle cache
+        - restore_cache:
+            keys:
+              - v1-gems-{{ checksum "Gemfile.lock" }}
+              # fallback to using the latest cache if no exact match is found
+              - v1-gems-
+
+        - run:
+            name: install gems
+            command: bundle check || bundle install
+
+        # Store cache
+        - save_cache:
+            key: v1-gems-{{ checksum "Gemfile.lock" }}
+            paths:
+              - vendor/bundle
+
+        # run tests!
+        - run:
+            name: run tests
+            command: bundle exec rake
+
+jobs:
+  ruby2.6.2:
+    docker:
+      - image: circleci/ruby:2.6.2
+        environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+
+    working_directory: ~/customerio-ruby
+
+    steps:
+      - checkout
+      - rubytest
+      
+  ruby2.5.5:
+    docker:
+      - image: circleci/ruby:2.5.5
+        environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+
+    working_directory: ~/customerio-ruby
+
+    steps:
+      - checkout
+      - rubytest
+
+  ruby2.4.5:
+    docker:
+      - image: circleci/ruby:2.4.5
+        environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+
+    working_directory: ~/customerio-ruby
+
+    steps:
+      - checkout
+      - rubytest
+
+  ruby1.9:
+    docker:
+      - image: ruby:1.9
+        environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+
+    working_directory: ~/customerio-ruby
+
+    steps:
+      - checkout
+      - rubytest
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - ruby2.6.2
+      - ruby2.5.5
+      - ruby2.4.5
+      - ruby1.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
 jobs:
   ruby262:
     docker:
-      - image: circleci/ruby:2.6.2
+      - image: ruby:2.6.2
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -48,7 +48,7 @@ jobs:
 
   ruby255:
     docker:
-      - image: circleci/ruby:2.5.5
+      - image: ruby:2.5.5
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -62,7 +62,7 @@ jobs:
 
   ruby245:
     docker:
-      - image: circleci/ruby:2.4.5
+      - image: ruby:2.4.5
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ version: 2.1
 commands:
   rubytest:
     description: Run ruby tests using rake
+    parameters:
+      version:
+        type: string
+        default: unknown
     steps:
       # Which version of bundler?
       - run:
@@ -12,7 +16,7 @@ commands:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - v1-gems-{{ checksum "Gemfile.lock" }}
+            - v1-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
             - v1-gems-
 
@@ -22,7 +26,7 @@ commands:
 
       # Store cache
       - save_cache:
-          key: v1-gems-{{ checksum "Gemfile.lock" }}
+          key: v1-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 
@@ -44,7 +48,8 @@ jobs:
 
     steps:
       - checkout
-      - rubytest
+      - rubytest:
+          version: "2.6"
 
   ruby25:
     docker:
@@ -58,7 +63,8 @@ jobs:
 
     steps:
       - checkout
-      - rubytest
+      - rubytest:
+          version: "2.5"
 
   ruby24:
     docker:
@@ -72,7 +78,8 @@ jobs:
 
     steps:
       - checkout
-      - rubytest
+      - rubytest:
+          version: "2.4"
 
   ruby19:
     docker:
@@ -86,7 +93,8 @@ jobs:
 
     steps:
       - checkout
-      - rubytest
+      - rubytest:
+          version: "1.9"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ commands:
           command: bundle exec rake
 
 jobs:
-  ruby262:
+  ruby26:
     docker:
-      - image: ruby:2.6.2
+      - image: ruby:2.6
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -46,9 +46,9 @@ jobs:
       - checkout
       - rubytest
 
-  ruby255:
+  ruby25:
     docker:
-      - image: ruby:2.5.5
+      - image: ruby:2.5
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -60,9 +60,9 @@ jobs:
       - checkout
       - rubytest
 
-  ruby245:
+  ruby24:
     docker:
-      - image: ruby:2.4.5
+      - image: ruby:2.4
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -92,7 +92,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - ruby262
-      - ruby255
-      - ruby245
+      - ruby26
+      - ruby25
+      - ruby24
       - ruby19

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ commands:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - v1-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
+            - v2-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-gems-
+            - v2-gems-
 
       - run:
           name: install gems
@@ -26,7 +26,7 @@ commands:
 
       # Store cache
       - save_cache:
-          key: v1-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
+          key: v2-gems-ruby<< parameters.version >>-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,38 @@
 version: 2.1
 
 commands:
-  - rubytest:
-      steps:
-        # Which version of bundler?
-        - run:
-            name: Which bundler?
-            command: bundle -v
+  rubytest:
+    description: Run ruby tests using rake
+    steps:
+      # Which version of bundler?
+      - run:
+          name: Which bundler?
+          command: bundle -v
 
-        # Restore bundle cache
-        - restore_cache:
-            keys:
-              - v1-gems-{{ checksum "Gemfile.lock" }}
-              # fallback to using the latest cache if no exact match is found
-              - v1-gems-
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - v1-gems-{{ checksum "Gemfile.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-gems-
 
-        - run:
-            name: install gems
-            command: bundle check || bundle install
+      - run:
+          name: install gems
+          command: bundle check || bundle install
 
-        # Store cache
-        - save_cache:
-            key: v1-gems-{{ checksum "Gemfile.lock" }}
-            paths:
-              - vendor/bundle
+      # Store cache
+      - save_cache:
+          key: v1-gems-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
-        # run tests!
-        - run:
-            name: run tests
-            command: bundle exec rake
+      # run tests!
+      - run:
+          name: run tests
+          command: bundle exec rake
 
 jobs:
-  ruby2.6.2:
+  ruby262:
     docker:
       - image: circleci/ruby:2.6.2
         environment:
@@ -44,8 +45,8 @@ jobs:
     steps:
       - checkout
       - rubytest
-      
-  ruby2.5.5:
+
+  ruby255:
     docker:
       - image: circleci/ruby:2.5.5
         environment:
@@ -59,7 +60,7 @@ jobs:
       - checkout
       - rubytest
 
-  ruby2.4.5:
+  ruby245:
     docker:
       - image: circleci/ruby:2.4.5
         environment:
@@ -73,7 +74,7 @@ jobs:
       - checkout
       - rubytest
 
-  ruby1.9:
+  ruby19:
     docker:
       - image: ruby:1.9
         environment:
@@ -91,7 +92,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - ruby2.6.2
-      - ruby2.5.5
-      - ruby2.4.5
-      - ruby1.9
+      - ruby262
+      - ruby255
+      - ruby245
+      - ruby19

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.rbc
 .bundle
 .config
-Gemfile.lock
 coverage
 InstalledFiles
 lib/bundler/man

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,3 @@ DEPENDENCIES
   rake (~> 10.5)
   rspec (= 3.3.0)
   webmock (= 1.24.2)
-
-BUNDLED WITH
-   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,49 @@
+PATH
+  remote: .
+  specs:
+    customerio (2.2.0)
+      multi_json (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    hashdiff (0.3.8)
+    json (2.2.0)
+    multi_json (1.13.1)
+    rake (10.5.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    safe_yaml (1.0.5)
+    webmock (1.24.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  addressable (~> 2.3.6)
+  customerio!
+  json
+  rake (~> 10.5)
+  rspec (= 3.3.0)
+  webmock (= 1.24.2)
+
+BUNDLED WITH
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A ruby client for the [Customer.io](http://customer.io) [event API](http://learn.customer.io/api/).
 
+[![CircleCI](https://circleci.com/gh/customerio/customerio-ruby.svg?style=svg)](https://circleci.com/gh/customerio/customerio-ruby)
 [![Build Status](https://secure.travis-ci.org/customerio/customerio-ruby.png?branch=master)](http://travis-ci.org/customerio/customerio-ruby)
 [![Code Climate](https://codeclimate.com/github/customerio/customerio-ruby/badges/gpa.svg)](https://codeclimate.com/github/customerio/customerio-ruby)
 


### PR DESCRIPTION
Part of customerio/issues#2786

Adds config to run tests in circleci. In Travis-CI we're testing against 6 versions of ruby:
- 1.9.2
- 1.9.2
- 2.0.0
- 2.1.6
- 2.2.2
- jruby-19mode

I narrowed down to the three latest stable releases and a 1.9 legacy version:
- 2.6.2
- 2.5.5
- 2.4.5
- 1.9

We can change up the versions tested against though if there's a good reason to include more (or less).