### PR TITLE
Add support for a separate region

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,27 @@
+
+## Customerio 3.1.0 - March 25, 2021
+### Added
+- Support for EU region
+
+### Removed
+### Changed
+- `Customerio::Client` and `CustomerIO::APIClient`  have a new parameter `region` that can be set to either `Customerio::Regions::EU` or `Customerio::Regions::US` (defaults to `Customerio::Regions::US`)
+
+## Customerio 3.0.0 - Dec 2, 2020
+
+### Added
+- Support for the Transactional API
+
+### Removed
+- `add_to_segment` and `remove_from_segment` methods
+- Support for non-JSON data
+
+### Changed
+- IDs in the URLs are now escaped.
+- Improved validations for data that's passed in.
+- Earlier, if you passed in an event name without a customer ID to the `track` method, we would create an anonymous event. That is now removed. To create an anonymous event, use the `anonymous_track` method.
+
+
 ## Customerio 3.0.0 - Dec 2, 2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ You'll be able to integrate **fully** with [Customer.io](http://customer.io) wit
 
 ### Setup
 
-Create an instance of the client with your [customer.io](http://customer.io) credentials
-which can be found on the [customer.io integration screen](https://fly.customer.io/account/customerio_integration).
+Create an instance of the client with your [Customer.io credentials](https://fly.customer.io/settings/api_credentials).
 
 If you're using Rails, create an initializer `config/initializers/customerio.rb`:
 
 ```ruby
-$customerio = Customerio::Client.new("YOUR SITE ID", "YOUR API SECRET KEY")
+$customerio = Customerio::Client.new("YOUR SITE ID", "YOUR API SECRET KEY", region: Customerio::Regions::US)
 ```
+
+`region` is optional and takes one of two values—`US` or `EU`. If you do not specify your region, we assume that your account is based in the US (`US`). If your account is based in the EU and you do not provide the correct region (`EU`), we'll route requests to our EU data centers accordingly, however this may cause data to be logged in the US. 
 
 ### Identify logged in customers
 
@@ -121,7 +122,7 @@ encourage your customers to perform an action.
 $customerio.track(5, "purchase", :type => "socks", :price => "13.99")
 ```
 
-**Note:** If you'd like to track events which occurred in the past, you can include a `timestamp` attribute
+**Note:** If you want to track events which occurred in the past, you can include a `timestamp` attribute
 (in seconds since the epoch), and we'll use that as the date the event occurred.
 
 ```ruby
@@ -195,7 +196,7 @@ Use `send_email` referencing your request to send a transactional message. [Lear
 ```ruby
 require "customerio"
 
-client = Customerio::APIClient.new("your API key")
+client = Customerio::APIClient.new("your API key", region: Customerio::Regions::US)
 
 request = Customerio::SendEmailRequest.new(
   to: "person@example.com",

--- a/lib/customerio.rb
+++ b/lib/customerio.rb
@@ -1,6 +1,7 @@
 require "customerio/version"
 
 module Customerio
+  require "customerio/regions"
   require "customerio/base_client"
   require "customerio/client"
   require "customerio/requests/send_email_request"

--- a/lib/customerio/api.rb
+++ b/lib/customerio/api.rb
@@ -4,9 +4,10 @@ require 'multi_json'
 module Customerio
   class APIClient
     def initialize(app_key, options = {})
-      options[:region] = Customerio::Regions::US if options[:region].nil? || options[:region].empty?
-      options[:url] = Customerio::Regions.api_url_for(options[:region]) if options[:url].nil? || options[:url].empty?
+      options[:region] = Customerio::Regions::US if options[:region].nil?
+      raise "region must be an instance of Customerio::Regions::Region" unless options[:region].is_a?(Customerio::Regions::Region)
 
+      options[:url] = options[:region].api_url if options[:url].nil? || options[:url].empty?
       @client = Customerio::BaseClient.new({ app_key: app_key }, options)
     end
 

--- a/lib/customerio/api.rb
+++ b/lib/customerio/api.rb
@@ -3,10 +3,10 @@ require 'multi_json'
 
 module Customerio
   class APIClient
-    DEFAULT_API_URL = 'https://api.customer.io'
-
     def initialize(app_key, options = {})
-      options[:url] = DEFAULT_API_URL if options[:url].nil? || options[:url].empty?
+      options[:region] = Customerio::Regions::US if options[:region].nil? || options[:region].empty?
+      options[:url] = Customerio::Regions.api_url_for(options[:region]) if options[:url].nil? || options[:url].empty?
+
       @client = Customerio::BaseClient.new({ app_key: app_key }, options)
     end
 

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -6,9 +6,10 @@ module Customerio
     class ParamError < RuntimeError; end
 
     def initialize(site_id, api_key, options = {})
-      options[:region] = Customerio::Regions::US if options[:region].nil? || options[:region].empty?
-      options[:url] = Customerio::Regions.track_url_for(options[:region]) if options[:url].nil? || options[:url].empty?
+      options[:region] = Customerio::Regions::US if options[:region].nil?
+      raise "region must be an instance of Customerio::Regions::Region" unless options[:region].is_a?(Customerio::Regions::Region)
 
+      options[:url] = options[:region].track_url if options[:url].nil? || options[:url].empty?
       @client = Customerio::BaseClient.new({ site_id: site_id, api_key: api_key }, options)
     end
 

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -2,13 +2,13 @@ require "addressable/uri"
 
 module Customerio
   class Client
-    DEFAULT_TRACK_URL = 'https://track.customer.io'
-
     class MissingIdAttributeError < RuntimeError; end
     class ParamError < RuntimeError; end
 
     def initialize(site_id, api_key, options = {})
-      options[:url] = DEFAULT_TRACK_URL if options[:url].nil? || options[:url].empty?
+      options[:region] = Customerio::Regions::US if options[:region].nil? || options[:region].empty?
+      options[:url] = Customerio::Regions.track_url_for(options[:region]) if options[:url].nil? || options[:url].empty?
+
       @client = Customerio::BaseClient.new({ site_id: site_id, api_key: api_key }, options)
     end
 

--- a/lib/customerio/regions.rb
+++ b/lib/customerio/regions.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'multi_json'
+
+module Customerio
+  class Regions
+    US = :us
+    EU = :eu
+
+    def self.track_url_for(region)
+      ensure_valid(region)
+
+      {
+        us: 'https://track.customer.io',
+        eu: 'https://track-eu.customer.io'
+      }[region]
+    end
+
+    def self.api_url_for(region)
+      ensure_valid(region)
+
+      {
+        us: 'https://api.customer.io',
+        eu: 'https://api-eu.customer.io'
+      }[region]
+    end
+
+    private
+
+    def self.ensure_valid(region)
+      raise "region must be one of #{US} or #{EU}" unless [EU, US].include?(region)
+    end
+  end
+end

--- a/lib/customerio/regions.rb
+++ b/lib/customerio/regions.rb
@@ -3,8 +3,8 @@ require 'multi_json'
 
 module Customerio
   class Regions
-    US = :us
-    EU = :eu
+    US = 'us'
+    EU = 'eu'
 
     def self.track_url_for(region)
       ensure_valid(region)
@@ -12,7 +12,7 @@ module Customerio
       {
         us: 'https://track.customer.io',
         eu: 'https://track-eu.customer.io'
-      }[region]
+      }[region.to_sym]
     end
 
     def self.api_url_for(region)
@@ -21,7 +21,7 @@ module Customerio
       {
         us: 'https://api.customer.io',
         eu: 'https://api-eu.customer.io'
-      }[region]
+      }[region.to_sym]
     end
 
     private

--- a/lib/customerio/regions.rb
+++ b/lib/customerio/regions.rb
@@ -2,32 +2,10 @@ require 'net/http'
 require 'multi_json'
 
 module Customerio
-  class Regions
-    US = 'us'
-    EU = 'eu'
+  module Regions
+    Region = Struct.new(:track_url, :api_url)
 
-    def self.track_url_for(region)
-      ensure_valid(region)
-
-      {
-        us: 'https://track.customer.io',
-        eu: 'https://track-eu.customer.io'
-      }[region.to_sym]
-    end
-
-    def self.api_url_for(region)
-      ensure_valid(region)
-
-      {
-        us: 'https://api.customer.io',
-        eu: 'https://api-eu.customer.io'
-      }[region.to_sym]
-    end
-
-    private
-
-    def self.ensure_valid(region)
-      raise "region must be one of #{US} or #{EU}" unless [EU, US].include?(region)
-    end
+    US = Customerio::Regions::Region.new('https://track.customer.io', 'https://api.customer.io').freeze
+    EU = Customerio::Regions::Region.new('https://track-eu.customer.io', 'https://api-eu.customer.io').freeze
   end
 end

--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,3 +1,3 @@
 module Customerio
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -30,7 +30,7 @@ describe Customerio::APIClient do
           { app_key: app_key },
           {
             region: Customerio::Regions::US,
-            url: Customerio::Regions.api_url_for(Customerio::Regions::US),
+            url: Customerio::Regions::US.api_url
           }
         )
     )
@@ -41,7 +41,7 @@ describe Customerio::APIClient do
   it "raises an error when an incorrect region is passed in" do
     expect {
       Customerio::APIClient.new("appkey", region: :au)
-    }.to raise_error /region must be one of us or eu/
+    }.to raise_error /region must be an instance of Customerio::Regions::Region/
   end
 
   [Customerio::Regions::US, Customerio::Regions::EU].each do |region|
@@ -54,7 +54,7 @@ describe Customerio::APIClient do
             { app_key: app_key },
             {
               region: region,
-              url: Customerio::Regions.api_url_for(region),
+              url: region.api_url
             }
           )
       )

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -21,6 +21,48 @@ describe Customerio::APIClient do
     MultiJson.dump(data)
   end
 
+  it "the base client is initialised with the correct values when no region is passed in" do
+    app_key = "appkey"
+
+    expect(Customerio::BaseClient).to(
+      receive(:new)
+        .with(
+          { app_key: app_key },
+          {
+            region: Customerio::Regions::US,
+            url: Customerio::Regions.api_url_for(Customerio::Regions::US),
+          }
+        )
+    )
+
+    client = Customerio::APIClient.new(app_key)
+  end
+
+  it "raises an error when an incorrect region is passed in" do
+    expect {
+      Customerio::APIClient.new("appkey", region: :au)
+    }.to raise_error /region must be one of us or eu/
+  end
+
+  [Customerio::Regions::US, Customerio::Regions::EU].each do |region|
+    it "the base client is initialised with the correct values when the region \"#{region}\" is passed in" do
+      app_key = "appkey"
+
+      expect(Customerio::BaseClient).to(
+        receive(:new)
+          .with(
+            { app_key: app_key },
+            {
+              region: region,
+              url: Customerio::Regions.api_url_for(region),
+            }
+          )
+      )
+
+      client = Customerio::APIClient.new(app_key, { region: region })
+    end
+  end
+
   describe "#send_email" do
     it "sends a POST request to the /api/send/email path" do
       req = Customerio::SendEmailRequest.new(

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -32,7 +32,7 @@ describe Customerio::Client do
           { site_id: site_id, api_key: api_key },
           {
             region: Customerio::Regions::US,
-            url: Customerio::Regions.track_url_for(Customerio::Regions::US),
+            url: Customerio::Regions::US.track_url
           }
         )
     )
@@ -43,7 +43,7 @@ describe Customerio::Client do
   it "raises an error when an incorrect region is passed in" do
     expect {
       Customerio::Client.new("siteid", "apikey", region: :au)
-    }.to raise_error /region must be one of us or eu/
+    }.to raise_error /region must be an instance of Customerio::Regions::Region/
   end
 
   [Customerio::Regions::US, Customerio::Regions::EU].each do |region|
@@ -57,7 +57,7 @@ describe Customerio::Client do
             { site_id: site_id, api_key: api_key },
             {
               region: region,
-              url: Customerio::Regions.track_url_for(region),
+              url: region.track_url
             }
           )
       )

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -40,6 +40,12 @@ describe Customerio::Client do
     client = Customerio::Client.new(site_id, api_key)
   end
 
+  it "raises an error when an incorrect region is passed in" do
+    expect {
+      Customerio::Client.new("siteid", "apikey", region: :au)
+    }.to raise_error /region must be one of us or eu/
+  end
+
   [Customerio::Regions::US, Customerio::Regions::EU].each do |region|
     it "the base client is initialised with the correct values when the region \"#{region}\" is passed in" do
       site_id = "SITE_ID"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -22,6 +22,44 @@ describe Customerio::Client do
     MultiJson.dump(data)
   end
 
+  it "the base client is initialised with the correct values when no region is passed in" do
+    site_id = "SITE_ID"
+    api_key = "API_KEY"
+
+    expect(Customerio::BaseClient).to(
+      receive(:new)
+        .with(
+          { site_id: site_id, api_key: api_key },
+          {
+            region: Customerio::Regions::US,
+            url: Customerio::Regions.track_url_for(Customerio::Regions::US),
+          }
+        )
+    )
+
+    client = Customerio::Client.new(site_id, api_key)
+  end
+
+  [Customerio::Regions::US, Customerio::Regions::EU].each do |region|
+    it "the base client is initialised with the correct values when the region \"#{region}\" is passed in" do
+      site_id = "SITE_ID"
+      api_key = "API_KEY"
+
+      expect(Customerio::BaseClient).to(
+        receive(:new)
+          .with(
+            { site_id: site_id, api_key: api_key },
+            {
+              region: region,
+              url: Customerio::Regions.track_url_for(region),
+            }
+          )
+      )
+
+      client = Customerio::Client.new(site_id, api_key, { region: region })
+    end
+  end
+
   it "uses json by default" do
     body = { id: 5, name: "Bob" }
     client = Customerio::Client.new("SITE_ID", "API_KEY")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,6 @@ require 'rspec'
 require 'webmock/rspec'
 
 RSpec.configure do |config|
-  config.expect_with(:rspec) { |c| c.syntax = :should }
-  config.mock_with(:rspec) { |c| c.syntax = :should }
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
+  config.mock_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end


### PR DESCRIPTION
This PR adds support for passing in a region (`eu` or `us`) which will update the API endpoints for both the Track and API clients.

### Usage

```
Customerio::Client.new('site-id', 'api-key') # defaults to Customerio::Regions::US

Customerio::Client.new('site-id', 'api-key', region: Customerio::Regions::US) # use US URLs

Customerio::Client.new('site-id', 'api-key', region: Customerio::Regions::EU) # use EU URLs
```