### PR TITLE
Add support for `region` api endpoint

### DIFF
--- a/lib/customerio/base_client.rb
+++ b/lib/customerio/base_client.rb
@@ -64,6 +64,8 @@ module Customerio
 
     def request_class(method)
       case method
+      when :get
+        Net::HTTP::Get
       when :post
         Net::HTTP::Post
       when :put

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -13,6 +13,16 @@ module Customerio
       @client = Customerio::BaseClient.new({ site_id: site_id, api_key: api_key }, options)
     end
 
+    def region
+      response = @client.request(:get, "/api/v1/accounts/region")
+      case response
+      when Net::HTTPSuccess
+        JSON.parse(response.body)
+      else
+        raise InvalidResponse.new(response.code, response.body)
+      end
+    end
+
     def identify(attributes)
       create_or_update(attributes)
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -546,4 +546,20 @@ describe Customerio::Client do
        lambda { client.delete_device(5, nil) }.should raise_error(Customerio::Client::ParamError)
     end
   end
+
+  describe "#region" do
+    it "sends a GET request to the customer.io's region API" do
+      stub_request(:get, api_uri('/api/v1/accounts/region')).
+        to_return(status: 200, body: { region: "eu" }.to_json, headers: {})
+
+      expect(client.region).to eq("region" => "eu")
+    end
+
+    it "throws an error when customer_id is missing" do
+      stub_request(:put, /track.customer.io/)
+        .to_return(status: 200, body: "", headers: {})
+
+      lambda { client.suppress(" ") }.should raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
+    end
+  end
 end


### PR DESCRIPTION
This change adds support for this api:
re: https://customer.io/docs/api/#tag/trackRegion