### PR TITLE
Add support for anonynmous events

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+## Customerio 4.0.0 - July 6, 2021
+### Removed
+- The `anonymous_track` method.
+
+### Added
+- The `track_anonymous` method replaces `anonymous_track`. This method requires an `anonymous_id` parameter and will no longer trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as ["invite events"](https://customer.io/docs/anonymous-events/#anonymous-or-invite). 
 
 ## Customerio 3.1.0 - March 25, 2021
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,10 +131,18 @@ $customerio.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp
 
 ### Tracking anonymous events
 
-You can also send anonymous events, for situations where you don't yet have a customer record but still want to trigger a campaign:
+You can also send anonymous events, for situations where you don't yet have a customer record yet. An anonymous event requires an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
+
+Anonymous events cannot trigger campaigns by themselves. To trigger a campaign, the anonymous event must be associated with a person within 72 hours of the `track_anonymous` request.
 
 ```ruby
-$customerio.anonymous_track("help_enquiry", :recipient => 'user@example.com')
+# Arguments
+# anonymous_id (required) - the id representing the unknown person.
+# name (required)         - the name of the event you want to track.
+# attributes (optional)   - any related information you want to attach to the
+#                           event.
+
+$customerio.track_anonymous(anonymous_id, "product_view", :type => "socks" )
 ```
 
 Use the `recipient` attribute to specify the email address to send the messages to. [See our documentation on how to use anonymous events for more details](https://learn.customer.io/recipes/invite-emails.html).

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -39,9 +39,11 @@ module Customerio
       create_customer_event(customer_id, event_name, attributes)
     end
 
-    def anonymous_track(event_name, attributes = {})
+    def track_anonymous(anonymous_id, event_name, attributes = {})
+      raise ParamError.new("anonymous_id must be a non-empty string") if is_empty?(anonymous_id)
       raise ParamError.new("event_name must be a non-empty string") if is_empty?(event_name)
-      create_anonymous_event(event_name, attributes)
+
+      create_anonymous_event(anonymous_id, event_name, attributes)
     end
 
     def add_device(customer_id, device_id, platform, data={})
@@ -106,16 +108,27 @@ module Customerio
     end
 
     def create_customer_event(customer_id, event_name, attributes = {})
-      create_event("#{customer_path(customer_id)}/events", event_name, attributes)
+      create_event(
+        url: "#{customer_path(customer_id)}/events",
+        event_name: event_name,
+        attributes: attributes
+      )
     end
 
-    def create_anonymous_event(event_name, attributes = {})
-      create_event("/api/v1/events", event_name, attributes)
+    def create_anonymous_event(anonymous_id, event_name, attributes = {})
+      create_event(
+        url: "/api/v1/events",
+        event_name: event_name,
+        anonymous_id: anonymous_id,
+        attributes: attributes
+      )
     end
 
-    def create_event(url, event_name, attributes = {})
+    def create_event(url:, event_name:, anonymous_id: nil, attributes: {})
       body = { :name => event_name, :data => attributes }
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
+      body[:anonymous_id] = anonymous_id unless anonymous_id.nil?
+
       @client.request_and_verify_response(:post, url, body)
     end
 

--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,3 +1,3 @@
 module Customerio
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -150,16 +150,18 @@ describe Customerio::Client do
       time = Time.now.to_i
 
       stub_request(:put, api_uri('/api/v1/customers/5')).with(
-        body: json({
+        body: {
           id: 5,
           email: "customer@example.com",
           created_at: time,
           first_name: "Bob",
-          plan: "basic"
-        })).to_return(status: 200, body: "", headers: {})
+          plan: "basic",
+          anonymous_id: "anon-id"
+        }).to_return(status: 200, body: "", headers: {})
 
       client.identify({
         id: 5,
+        anonymous_id: "anon-id",
         email: "customer@example.com",
         created_at: time,
         first_name: "Bob",

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -381,31 +381,35 @@ describe Customerio::Client do
     end
 
     context "tracking an anonymous event" do
+      let(:anon_id) { "anon-id" }
+
       it "sends a POST request to the customer.io's anonymous event API" do
         stub_request(:post, api_uri('/api/v1/events')).
-          with(body: json({ name: "purchase", data: {} })).
+          with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
           to_return(status: 200, body: "", headers: {})
 
-        client.anonymous_track("purchase")
+        client.track_anonymous(anon_id, "purchase")
       end
 
       it "sends any optional event attributes" do
         stub_request(:post, api_uri('/api/v1/events')).
-          with(body: json({
+          with(body: {
+            anonymous_id: anon_id,
             name: "purchase",
             data: {
               type: "socks",
               price: "13.99"
             }
-          })).
+          }).
           to_return(status: 200, body: "", headers: {})
 
-        client.anonymous_track("purchase", type: "socks", price: "13.99")
+        client.track_anonymous(anon_id, "purchase", type: "socks", price: "13.99")
       end
 
       it "allows sending of a timestamp" do
         stub_request(:post, api_uri('/api/v1/events')).
-          with(body: json({
+          with(body: {
+            anonymous_id: anon_id,
             name: "purchase",
             data: {
               type: "socks",
@@ -413,73 +417,34 @@ describe Customerio::Client do
               timestamp: 1561231234
             },
             timestamp: 1561231234
-          })).
+          }).
           to_return(status: 200, body: "", headers: {})
 
-        client.anonymous_track("purchase", type: "socks", price: "13.99", timestamp: 1561231234)
+        client.track_anonymous(anon_id, "purchase", type: "socks", price: "13.99", timestamp: 1561231234)
       end
-    end
-  end
 
-  describe "#anonymous_track" do
-    it "raises an error if POST doesn't return a 2xx response code" do
-      stub_request(:post, api_uri('/api/v1/events')).
-        with(body: json(name: "purchase", data: {})).
-        to_return(status: 500, body: "", headers: {})
+      it "raises an error if POST doesn't return a 2xx response code" do
+          stub_request(:post, api_uri('/api/v1/events')).
+            with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
+            to_return(status: 500, body: "", headers: {})
 
-      lambda { client.anonymous_track("purchase") }.should raise_error(Customerio::InvalidResponse)
-    end
+        lambda { client.track_anonymous(anon_id, "purchase") }.should raise_error(Customerio::InvalidResponse)
+      end
 
-    it "throws an error when event_name is missing" do
-      stub_request(:put, /track.customer.io/)
-        .to_return(status: 200, body: "", headers: {})
+      it "throws an error when anonymous_id is missing" do
+          stub_request(:post, api_uri('/api/v1/events')).
+            with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
+            to_return(status: 500, body: "", headers: {})
 
-      lambda { client.anonymous_track(" ") }.should raise_error(Customerio::Client::ParamError, "event_name must be a non-empty string")
-    end
+        lambda { client.track_anonymous("", "some_event") }.should raise_error(Customerio::Client::ParamError)
+      end
 
-    it "uses the site_id and api key for basic auth and sends the event name" do
-      stub_request(:post, api_uri('/api/v1/events')).
-        with(body: json(name: "purchase", data: {})).
-        to_return(status: 200, body: "", headers: {})
+      it "throws an error when event_name is missing" do
+          stub_request(:post, api_uri('/api/v1/events')).
+            with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
+            to_return(status: 500, body: "", headers: {})
 
-      client.anonymous_track("purchase")
-    end
-
-    it "sends any optional event attributes" do
-      stub_request(:post, api_uri('/api/v1/events')).
-          with(body: {
-            name: "purchase",
-            data: {
-              type: "socks",
-              price: "27.99"
-            },
-          }).
-
-        to_return(status: 200, body: "", headers: {})
-
-      client.anonymous_track("purchase", type: "socks", price: "27.99")
-    end
-
-    it "allows sending of a timestamp" do
-      stub_request(:post, api_uri('/api/v1/events')).
-          with(body: json({
-            name: "purchase",
-            data: {
-              type: "socks",
-              price: "27.99",
-              timestamp: 1561235678
-            },
-            timestamp: 1561235678
-          })).
-
-        to_return(status: 200, body: "", headers: {})
-
-      client.anonymous_track("purchase", type: "socks", price: "27.99", timestamp: 1561235678)
-    end
-
-    context "too many arguments are passed" do
-      it "throws an error" do
-        lambda { client.anonymous_track("purchase", "text", type: "socks", price: "27.99") }.should raise_error(ArgumentError)
+        lambda { client.track_anonymous(anon_id, "") }.should raise_error(Customerio::Client::ParamError)
       end
     end
   end


### PR DESCRIPTION
This PR adds support for sending anonymous events. These anonymous events can later be associated / identified with an existing customer. It'll be a breaking change as we're removing the old `anonymous_track` method.

###### Usage

```
client = Customerio::Client.new(…)
client.track_anonymous(anonymous_id, "test_event", { ... })
```

We don't generate anonymous IDs. The user has to generate them and pass them to the `track_anonymous` method.