### PR TITLE
feat: add support for invite-type anonymous event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,22 @@ Anonymous events cannot trigger campaigns by themselves. To trigger a campaign, 
 
 ```ruby
 # Arguments
-# anonymous_id (required) - the id representing the unknown person.
-# name (required)         - the name of the event you want to track.
-# attributes (optional)   - any related information you want to attach to the
-#                           event.
+# anonymous_id (required, nullable) - the id representing the unknown person.
+# name (required)                   - the name of the event you want to track.
+# attributes (optional)             - related information you want to attach to the event.
 
 $customerio.track_anonymous(anonymous_id, "product_view", :type => "socks" )
 ```
 
 Use the `recipient` attribute to specify the email address to send the messages to. [See our documentation on how to use anonymous events for more details](https://customer.io/docs/invite-emails/).
+
+#### Anonymous invite events
+
+If you previously sent [invite events](https://customer.io/docs/anonymous-invite-emails/), you can achieve the same functionality by sending an anonymous event with `nil` for the anonymous identifier. To send anonymous invites, your event *must* include a `recipient` attribute. 
+
+```ruby
+$customerio.track_anonymous(nil, "invite", :recipient => "new.person@example.com" )
+```
 
 ### Adding a mobile device
 

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -52,7 +52,6 @@ module Customerio
     end
 
     def track_anonymous(anonymous_id, event_name, attributes = {})
-      raise ParamError.new("anonymous_id must be a non-empty string") if is_empty?(anonymous_id)
       raise ParamError.new("event_name must be a non-empty string") if is_empty?(event_name)
 
       create_anonymous_event(anonymous_id, event_name, attributes)
@@ -171,7 +170,7 @@ module Customerio
     def create_event(url:, event_name:, anonymous_id: nil, attributes: {})
       body = { :name => event_name, :data => attributes }
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
-      body[:anonymous_id] = anonymous_id unless anonymous_id.nil?
+      body[:anonymous_id] = anonymous_id unless is_empty?(anonymous_id)
 
       @client.request_and_verify_response(:post, url, body)
     end

--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,3 +1,3 @@
 module Customerio
-  VERSION = "4.2.0"
+  VERSION = "4.3.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -433,12 +433,20 @@ describe Customerio::Client do
         lambda { client.track_anonymous(anon_id, "purchase") }.should raise_error(Customerio::InvalidResponse)
       end
 
-      it "throws an error when anonymous_id is missing" do
+      it "doesn't pass along anonymous_id if it is blank" do
           stub_request(:post, api_uri('/api/v1/events')).
-            with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
-            to_return(status: 500, body: "", headers: {})
+            with(body: { name: "some_event", data: {} }).
+            to_return(status: 200, body: "", headers: {})
 
-        lambda { client.track_anonymous("", "some_event") }.should raise_error(Customerio::Client::ParamError)
+        client.track_anonymous("", "some_event")
+      end
+
+      it "doesn't pass along anonymous_id if it is nil" do
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(body: { name: "some_event", data: {} }).
+          to_return(status: 200, body: "", headers: {})
+
+        client.track_anonymous(nil, "some_event")
       end
 
       it "throws an error when event_name is missing" do


### PR DESCRIPTION
Re-introduces support for anonymous event tracking using activity items unassociated with profiles by passing in a blank value for `anonymous_id`

**Usage:**

```ruby
track_anonymous(nil, "my-event", {"foo"=>"bar"})
```