### PR TITLE
Add get method to BaseClient

### DIFF
--- a/lib/customerio/base_client.rb
+++ b/lib/customerio/base_client.rb
@@ -72,6 +72,8 @@ module Customerio
         Net::HTTP::Put
       when :delete
         Net::HTTP::Delete
+      when :get
+        Net::HTTP::Get
       else
         raise InvalidRequest.new("Invalid request method #{method.inspect}")
       end


### PR DESCRIPTION
- add method `get` to base client

by adding this method is possible to use this lib as to fetch other endpoints from customer io, by just using the BaseClient to fetch the endpoints