### PR TITLE
Add id support to customer and anonymous events

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -170,6 +170,7 @@ module Customerio
     def create_event(url:, event_name:, anonymous_id: nil, attributes: {})
       body = { :name => event_name, :data => attributes }
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
+      body[:id] = attributes[:id] if valid_ulid?(attributes[:id])
       body[:anonymous_id] = anonymous_id unless is_empty?(anonymous_id)
 
       @client.request_and_verify_response(:post, url, body)
@@ -177,6 +178,10 @@ module Customerio
 
     def valid_timestamp?(timestamp)
       timestamp && timestamp.is_a?(Integer) && timestamp > 999999999 && timestamp < 100000000000
+    end
+
+    def valid_ulid?(id)
+      id && id.is_a?(String) && id.length == 26
     end
 
     def is_empty?(val)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -382,6 +382,54 @@ describe Customerio::Client do
       client.track(5, "purchase", type: "socks", price: "13.99", timestamp: "Hello world")
     end
 
+    it "allows sending of an id" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            type: "socks",
+            price: "13.99",
+            id: "01G653VCS2Z4KQYQJCBVVB2CCW"
+          },
+          id: "01G653VCS2Z4KQYQJCBVVB2CCW"
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(5, "purchase", type: "socks", price: "13.99", id: "01G653VCS2Z4KQYQJCBVVB2CCW")
+    end
+
+    it "doesn't send id if id isn't a string" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            type: "socks",
+            price: "13.99",
+            id: 1234
+          }
+        })).
+
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(5, "purchase", type: "socks", price: "13.99", id: 1234)
+    end
+
+    it "doesn't send id if id isn't a ULID" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            type: "socks",
+            price: "13.99",
+            id: "1234"
+          }
+        })).
+
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(5, "purchase", type: "socks", price: "13.99", id: "1234")
+    end
+
     context "tracking an anonymous event" do
       let(:anon_id) { "anon-id" }
 
@@ -425,6 +473,23 @@ describe Customerio::Client do
         client.track_anonymous(anon_id, "purchase", type: "socks", price: "13.99", timestamp: 1561231234)
       end
 
+      it "allows sending of an id" do
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(body: {
+            anonymous_id: anon_id,
+            name: "purchase",
+            data: {
+              type: "socks",
+              price: "13.99",
+              id: "01G653VCS2Z4KQYQJCBVVB2CCW"
+            },
+            id: "01G653VCS2Z4KQYQJCBVVB2CCW"
+          }).
+          to_return(status: 200, body: "", headers: {})
+
+        client.track_anonymous(anon_id, "purchase", type: "socks", price: "13.99", id: "01G653VCS2Z4KQYQJCBVVB2CCW")
+      end
+      
       it "raises an error if POST doesn't return a 2xx response code" do
           stub_request(:post, api_uri('/api/v1/events')).
             with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).


### PR DESCRIPTION
This change adds support for the `id` request parameter to the following endpoints:
- https://customer.io/docs/api/#operation/track
- https://customer.io/docs/api/#operation/trackAnonymous

This parameter is used for event deduplication.