### PR TITLE
Add Ruby 3.0, 3.1, 3.2 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ubuntu-latest
     env:
       BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle


### PR DESCRIPTION
This PR includes the current Ruby versions in the matrix.