### PR TITLE
Transactional - amp_body prop to body_amp for consistency

### DIFF
--- a/lib/customerio/requests/send_email_request.rb
+++ b/lib/customerio/requests/send_email_request.rb
@@ -29,7 +29,7 @@ module Customerio
       bcc
       subject
       body
-      body_plaintext
+      body_plain
       body_amp
       fake_bcc
       disable_message_retention

--- a/lib/customerio/requests/send_email_request.rb
+++ b/lib/customerio/requests/send_email_request.rb
@@ -29,8 +29,8 @@ module Customerio
       bcc
       subject
       body
-      plaintext_body
-      amp_body
+      body_plaintext
+      body_amp
       fake_bcc
       disable_message_retention
       send_to_unsubscribed


### PR DESCRIPTION
Updating Transactional API endpoint properties `amp_body` `amp_plaintext` to `body_amp` `body_plaintext` to maintain consistency with Newsletters API.