### PR TITLE
Allow customer_id to be specified in identify URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ if you pass along the current subscription plan (free / basic / premium) for you
 set up triggers which are only sent to customers who have subscribed to a
 particular plan (e.g. "premium").
 
-You'll want to indentify your customers when they sign up for your app and any time their
+You'll want to identify your customers when they sign up for your app and any time their
 key information changes. This keeps [Customer.io](https://customer.io) up to date with your customer information.
 
 ```ruby
@@ -87,6 +87,25 @@ key information changes. This keeps [Customer.io](https://customer.io) up to dat
 #                         must at least pass in an id, email, and created_at timestamp.
 
 $customerio.identify(
+  :id => 5,
+  :email => "bob@example.com",
+  :created_at => customer.created_at.to_i,
+  :first_name => "Bob",
+  :plan => "basic"
+)
+```
+
+If you wish to specify a customer ID that is different than the one used in the `id` attribute, you can do so by using the `identify_customer_id` method:
+```ruby
+# Arguments
+# customer_id (required) - the customer ID to use for this customer, may be an id, email address, or the cio_id. This attribute
+#                         will be used to construct the URL but not sent in the body attributes.
+# attributes (required) - a hash of information about the customer. You can pass any
+#                         information that would be useful in your triggers. You 
+#                         must at least pass in an id, email, and created_at timestamp.
+
+$customerio.identify_customer_id(
+  :customer_id => "cio_5",
   :id => 5,
   :email => "bob@example.com",
   :created_at => customer.created_at.to_i,

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -29,6 +29,10 @@ module Customerio
       create_or_update(attributes)
     end
 
+    def identify_customer_id(customer_id: nil, **attributes)
+      create_or_update_customer_id(customer_id, **attributes)
+    end
+
     def delete(customer_id)
       raise ParamError.new("customer_id must be a non-empty string") if is_empty?(customer_id)
       @client.request_and_verify_response(:delete, customer_path(customer_id))
@@ -150,10 +154,14 @@ module Customerio
     end
 
     def create_or_update(attributes = {})
-      attributes = Hash[attributes.map { |(k,v)| [ k.to_sym, v ] }]
-      raise MissingIdAttributeError.new("Must provide a customer id") if is_empty?(attributes[:id])
+      create_or_update_customer_id(attributes[:id] || attributes["id"], attributes)
+    end
 
-      url = customer_path(attributes[:id])
+    def create_or_update_customer_id(customer_id, attributes = {})
+      attributes = Hash[attributes.map { |(k,v)| [ k.to_sym, v ] }]
+      raise MissingIdAttributeError.new("Must provide a customer id") if is_empty?(customer_id)
+
+      url = customer_path(customer_id)
       @client.request_and_verify_response(:put, url, attributes)
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -183,6 +183,14 @@ describe Customerio::Client do
 
       lambda { client.identify(attributes) }.should_not raise_error()
     end
+
+    it "uses provided url_id rather than id" do
+      stub_request(:put, api_uri('/api/v1/customers/cio_5')).
+        with(body: json(id: "5")).
+        to_return(status: 200, body: "", headers: {})
+
+      client.identify_customer_id(customer_id: "cio_5", id: "5")
+    end
   end
 
   describe "#delete" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -184,7 +184,7 @@ describe Customerio::Client do
       lambda { client.identify(attributes) }.should_not raise_error()
     end
 
-    it "uses provided url_id rather than id" do
+    it "uses provided customer_id rather than id" do
       stub_request(:put, api_uri('/api/v1/customers/cio_5')).
         with(body: json(id: "5")).
         to_return(status: 200, body: "", headers: {})
@@ -618,7 +618,7 @@ describe Customerio::Client do
       }.to raise_error(Customerio::Client::ParamError, 'timestamp must be a valid timestamp')
     end
   end
-  
+
   describe "#merge_customers" do
     before(:each) do
       @client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)


### PR DESCRIPTION
This is a rebase of the work here:

https://github.com/trwalzer/customerio-ruby

The issue is here:

https://github.com/customerio/customerio-ruby/issues/78

I did nothing new, but I wanted to use the technique @trwazler added, but with a more recent version of the gem.