### PR TITLE
leftover JSON references

### DIFF
--- a/lib/customerio/api.rb
+++ b/lib/customerio/api.rb
@@ -17,9 +17,9 @@ module Customerio
 
       case response
       when Net::HTTPSuccess then
-        JSON.parse(response.body)
+        MultiJson.load(response.body)
       when Net::HTTPBadRequest then
-        json = JSON.parse(response.body)
+        json = MultiJson.load(response.body)
         raise Customerio::InvalidResponse.new(response.code, json['meta']['error'], response)
       else
         raise InvalidResponse.new(response.code, response.body)
@@ -32,9 +32,9 @@ module Customerio
 
       case response
       when Net::HTTPSuccess then
-        JSON.parse(response.body)
+        MultiJson.load(response.body)
       when Net::HTTPBadRequest then
-        json = JSON.parse(response.body)
+        json = MultiJson.load(response.body)
         raise Customerio::InvalidResponse.new(response.code, json['meta']['error'], response)
       else
         raise InvalidResponse.new(response.code, response.body)


### PR DESCRIPTION
I was trying a ruby example upon setting up transactional email when an error came up

```
[redacted]2.7.6/lib/ruby/gems/2.7.0/gems/customerio-5.1.0/lib/customerio/api.rb:20:in `send_email': uninitialized constant Customerio::APIClient::JSON (NameError)
```

I dug around and found it could be some leftover that hasn't migrated to `multi_json` yet. I noticed it's already a dependency of `customerio` gem.

I changed it on my local and works fine after that. 