### PR TITLE
clairfy transactional example with email

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Create a new `SendEmailRequest` object containing:
 
 * `transactional_message_id`: the ID of the transactional message you want to send, or the `body`, `from`, and `subject` of a new message.
 * `to`: the email address of your recipients 
-* an `identifiers` object containing the `id` of your recipient. If the `id` does not exist, Customer.io creates it.
+* an `identifiers` object containing the `email` and/or `id` of your recipient. If the person you reference by email or ID does not exist, Customer.io creates them.
 * a `message_data` object containing properties that you want reference in your message using liquid.
 * You can also send attachments with your message. Use `attach` to encode attachments.
 
@@ -249,7 +249,7 @@ request = Customerio::SendEmailRequest.new(
     products: [],
   },
   identifiers: {
-    id: "2",
+    example: "person@example.com",
   },
 )
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ request = Customerio::SendEmailRequest.new(
     products: [],
   },
   identifiers: {
-    example: "person@example.com",
+    email: "person@example.com",
   },
 )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating the transactional email `identifiers` guidance and example; no runtime code or API behavior changes.
> 
> **Overview**
> Clarifies the README’s transactional email docs to state that `SendEmailRequest.identifiers` can include `email` and/or `id` (and that missing people are auto-created), and updates the sample request to use an `email` identifier instead of an `id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51248853de00cd2acc018d48ed52d0d81a659a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->