### PR TITLE
Add unique_track method

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -197,7 +197,7 @@ module Customerio
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
       body[:anonymous_id] = anonymous_id unless is_empty?(anonymous_id)
       body[:type] = event_type unless is_empty?(event_type)
-      body[:event_id] = event_id unless is_empty?(event_id)
+      body[:id] = event_id unless is_empty?(event_id)
 
       @client.request_and_verify_response(:post, url, body)
     end

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -165,12 +165,11 @@ module Customerio
       @client.request_and_verify_response(:put, url, attributes)
     end
 
-    def create_customer_event(customer_id, event_name, attributes = {}, id = nil)
-      url = id ? "#{customer_path(customer_id)}/events/#{id}" : "#{customer_path(customer_id)}/events"
-
+    def create_customer_event(customer_id, event_name, attributes = {}, event_id = nil)
       create_event(
-        url: url,
+        url: "#{customer_path(customer_id)}/events",
         event_name: event_name,
+        event_id: event_id,
         attributes: attributes
       )
     end
@@ -193,11 +192,12 @@ module Customerio
       )
     end
 
-    def create_event(url:, event_name:, anonymous_id: nil, event_type: nil, attributes: {})
+    def create_event(url:, event_name:, anonymous_id: nil, event_type: nil, event_id: nil, attributes: {})
       body = { :name => event_name, :data => attributes }
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
       body[:anonymous_id] = anonymous_id unless is_empty?(anonymous_id)
       body[:type] = event_type unless is_empty?(event_type)
+      body[:event_id] = event_id unless is_empty?(event_id)
 
       @client.request_and_verify_response(:post, url, body)
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -392,6 +392,25 @@ describe Customerio::Client do
       client.track(5, "purchase", type: "socks", price: "13.99", timestamp: "Hello world")
     end
 
+    context "tracking a unique event" do
+      let(:event_id) { "01HB4HBDKTFWYZCK01DMRSWRFD" }
+
+      it "throws an error when event_id is invalid ulid" do
+        stub_request(:put, /track.customer.io/)
+          .to_return(status: 200, body: "", headers: {})
+
+        lambda { client.unique_track(" ", 1, "test_event") }.should raise_error(Customerio::Client::ParamError, "event_id must be a valid ULID")
+      end
+
+      it "sends a POST request to the customer.io's anonymous event API" do
+        stub_request(:post, api_uri("/api/v1/customers/5/events/#{event_id}")).
+          with(body: { name: "purchase", data: {} }).
+          to_return(status: 200, body: "", headers: {})
+
+        client.unique_track(event_id, 5, "purchase")
+      end
+    end
+
     context "tracking an anonymous event" do
       let(:anon_id) { "anon-id" }
 


### PR DESCRIPTION
Proposal for #107

Adds an `unique_track` method to ensure uniqueness when tracking the same event multiple times, by adding a ULID.

Ideally, we would add this to the existing `track` method, but doing so in a backwards-compatible way requires jumping through various hoops. I figured a separate method might be simpler.