### PR TITLE
Allow customer_id to be specified in identify URL

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,6 @@
 ## Customerio 5.3.0 - December 8, 2023
-### Added
-- The `identify_customer_id` method has been added. This allows the customer ID to be specified separately from the attributes. This allows a person to be updated by identifying them by e.g.: their email address. Thanks to trwalzer, jrbeck and jeremyw for these changes.
+### Changed
+- The `identify` method has been updated to allow the customer ID to be specified separately from the attributes, using the `customer_id` attribute. This allows a person to be updated by identifying them by e.g.: their email address. Thanks to trwalzer, jrbeck and jeremyw for the original changes that this is based on.
 
 ## Customerio 5.2.0 - December 8, 2023
 ### Changed

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## Customerio 5.3.0 - December 8, 2023
+### Added
+- The `identify_customer_id` method has been added. This allows the customer ID to be specified separately from the attributes. This allows a person to be updated by identifying them by e.g.: their email address. Thanks to trwalzer, jrbeck and jeremyw for these changes.
+
 ## Customerio 5.2.0 - December 8, 2023
 ### Changed
 - The `identify` method will now automatically use the `cio_id` attribute as the customer ID when calling the track service. This allows a customer to be updated using `identify` to modify the `id` and `email` attributes.

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 ## Customerio 5.3.0 - December 8, 2023
 ### Changed
 - The `identify` method has been updated to allow the customer ID to be specified separately from the attributes, using the `customer_id` attribute. This allows a person to be updated by identifying them by e.g.: their email address. Thanks to trwalzer, jrbeck and jeremyw for the original changes that this is based on.
+- It is no longer possible to set the `customer_id` attribute on a person. This is a side-effect of the changes to the `identify` method.
 
 ## Customerio 5.2.0 - December 8, 2023
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,7 +95,29 @@ $customerio.identify(
 )
 ```
 
-### Updating customers
+### Updating customers: Using other IDs
+
+If you wish to specify a customer ID that is different than the one used in the `id` attribute, you can do so by using the `identify_customer_id` method:
+
+```ruby
+# Arguments
+# customer_id (required) - the customer ID to use for this customer, may be an id, email address, or the cio_id.
+#                         This will be used to construct the URL but not sent in the body attributes.
+# attributes (required) - a hash of information about the customer. You can pass any
+#                         information that would be useful in your triggers. You
+#                         must at least pass in an id, email, and created_at timestamp.
+
+$customerio.identify_customer_id(
+  :customer_id => "bob@example.com",
+  :id => 5,
+  :email => "bob@example.com",
+  :created_at => customer.created_at.to_i,
+  :first_name => "Bob",
+  :plan => "basic"
+)
+```
+
+### Updating customers: Changing identifiers
 
 You can use the identify operation to update customers.
 If you need to change the `id` or `email` identifiers for a customer,

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also use this method to make other updates to the person using the `cio_
 ### Updating customers: Using email address
 
 If you need to identify a person using their email address, then you can do so
-by using the `identify_customer_id` method. This allows you to specify
+by passing in a customer ID to the `identify` method. This allows you to specify
 a customer ID that is different than the one used in the `id` attribute. E.g.:
 
 ```ruby
@@ -131,17 +131,16 @@ a customer ID that is different than the one used in the `id` attribute. E.g.:
 #                         information that would be useful in your triggers. You
 #                         must at least pass in an id, email, and created_at timestamp.
 
-$customerio.identify_customer_id(
+$customerio.identify(
   :customer_id => "bob@example.com",
-  :id => 5,
-  :email => "bob@example.com",
-  :created_at => customer.created_at.to_i,
-  :first_name => "Bob",
-  :plan => "basic"
+  :location => "Australia"
 )
 ```
 
-Note: If you want to use the `cio_id` in the `customer_id` field of `identify_customer_id`, you will need to prefix it with `"cio_"`. E.g.: `"cio_f000000d"` for a `cio_id` of `f000000d`.
+Note:
+
+ * If you want to use the `cio_id` in the `customer_id` field of `identify_customer_id`, you will need to prefix it with `"cio_"`. E.g.: `"cio_f000000d"` for a `cio_id` of `f000000d`.
+ * The `identify` method can identify the person using one of `customer_id`, `cio_id` or `id`. The order of precedence is `customer_id` > `cio_id` > `id`.
 
 ### Deleting customers
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,33 @@ $customerio.identify(
 )
 ```
 
-### Updating customers: Using other IDs
+### Updating customers: Changing identifiers
 
-If you wish to specify a customer ID that is different than the one used in the `id` attribute, you can do so by using the `identify_customer_id` method:
+You can use the identify operation to update customers.
+If you need to change the `id` or `email` identifiers for a customer,
+you will need to pass in the `cio_id` identifier.
+`cio_id` is a unique identifier set by Customer.io, used to reference a person,
+and cannot be changed.
+
+E.g.: if the customer created in the identify operation above was given the `cio_id` of `"f000000d"`, you could change its ID and email address using:
+
+```ruby
+$customerio.identify(
+  :cio_id => "f000000d",
+  :id => 1005,
+  :email => "bob.fullname@example.com"
+)
+```
+
+This method requires either the `id` or `cio_id` for the person. It does not work with email addresses.
+
+You can also use this method to make other updates to the person using the `cio_id`.
+
+### Updating customers: Using email address
+
+If you need to identify a person using their email address, then you can do so
+by using the `identify_customer_id` method. This allows you to specify
+a customer ID that is different than the one used in the `id` attribute. E.g.:
 
 ```ruby
 # Arguments
@@ -117,23 +141,7 @@ $customerio.identify_customer_id(
 )
 ```
 
-### Updating customers: Changing identifiers
-
-You can use the identify operation to update customers.
-If you need to change the `id` or `email` identifiers for a customer,
-you will need to pass in the `cio_id` identifier.
-`cio_id` is a unique identifier set by Customer.io, used to reference a person,
-and cannot be changed.
-
-E.g.: if the customer created in the identify operation above was given the `cio_id` of `"f000000d"`, you could change its ID and email address using:
-
-```ruby
-$customerio.identify(
-  :cio_id => "f000000d",
-  :id => 1005,
-  :email => "bob.fullname@example.com"
-)
-```
+Note: If you want to use the `cio_id` in the `customer_id` field of `identify_customer_id`, you will need to prefix it with `"cio_"`. E.g.: `"cio_f000000d"` for a `cio_id` of `f000000d`.
 
 ### Deleting customers
 

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -29,6 +29,10 @@ module Customerio
       create_or_update(attributes)
     end
 
+    def identify_customer_id(customer_id: nil, **attributes)
+      create_or_update_customer_id(customer_id, **attributes)
+    end
+
     def delete(customer_id)
       raise ParamError.new("customer_id must be a non-empty string") if is_empty?(customer_id)
       @client.request_and_verify_response(:delete, customer_path(customer_id))
@@ -160,6 +164,14 @@ module Customerio
       customer_id = attributes[:id]
       if !is_empty?(attributes[:cio_id])
         customer_id = "cio_" + attributes[:cio_id]
+      end
+      create_or_update_customer_id(customer_id, attributes)
+    end
+
+    def create_or_update_customer_id(customer_id, attributes = {})
+      attributes = Hash[attributes.map { |(k,v)| [ k.to_sym, v ] }]
+      if is_empty?(customer_id)
+        raise MissingIdAttributeError.new("Must provide a customer id")
       end
       url = customer_path(customer_id)
       @client.request_and_verify_response(:put, url, attributes)

--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,3 +1,3 @@
 module Customerio
-  VERSION = "5.2.0"
+  VERSION = "5.3.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -225,6 +225,50 @@ describe Customerio::Client do
     end
   end
 
+  describe "#identify_customer_id" do
+    it "uses provided id rather than id" do
+      stub_request(:put, api_uri('/api/v1/customers/1234')).
+        with(body: json(id: "5")).
+        to_return(status: 200, body: "", headers: {})
+
+      client.identify_customer_id(
+        customer_id: "1234",
+        id: "5"
+      )
+    end
+
+    it "uses provided cio_id rather than id" do
+      stub_request(:put, api_uri('/api/v1/customers/cio_5')).
+        with(body: json(id: "5")).
+        to_return(status: 200, body: "", headers: {})
+
+      client.identify_customer_id(
+        customer_id: "cio_5",
+        id: "5"
+      )
+    end
+
+    it "uses provided email rather than id" do
+      stub_request(:put, api_uri('/api/v1/customers/customer@example.com')).
+        with(body: json(id: "5")).
+        to_return(status: 200, body: "", headers: {})
+
+      client.identify_customer_id(
+        customer_id: "customer@example.com",
+        id: "5"
+      )
+    end
+
+    it "requires a customer_id attribute" do
+      lambda { client.identify_customer_id() }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      lambda { client.identify_customer_id(customer_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      # None of these are customer_id
+      lambda { client.identify_customer_id(id: "5") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      lambda { client.identify_customer_id(cio_id: "cio_5") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      lambda { client.identify_customer_id(email: "customer@example.com") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+    end
+  end
+
   describe "#delete" do
     it "sends a DELETE request to the customer.io's event API" do
       stub_request(:delete, api_uri('/api/v1/customers/5')).
@@ -650,7 +694,7 @@ describe Customerio::Client do
       }.to raise_error(Customerio::Client::ParamError, 'timestamp must be a valid timestamp')
     end
   end
-  
+
   describe "#merge_customers" do
     before(:each) do
       @client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -173,6 +173,7 @@ describe Customerio::Client do
       lambda { client.identify(email: "customer@example.com") }.should raise_error(Customerio::Client::MissingIdAttributeError)
       lambda { client.identify(id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
       lambda { client.identify(cio_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      lambda { client.identify(customer_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
     end
 
     it 'should not raise errors when attribute keys are strings' do
@@ -223,15 +224,13 @@ describe Customerio::Client do
         location: "here"
       })
     end
-  end
 
-  describe "#identify_customer_id" do
     it "uses provided id rather than id" do
       stub_request(:put, api_uri('/api/v1/customers/1234')).
         with(body: json(id: "5")).
         to_return(status: 200, body: "", headers: {})
 
-      client.identify_customer_id(
+      client.identify(
         customer_id: "1234",
         id: "5"
       )
@@ -242,7 +241,7 @@ describe Customerio::Client do
         with(body: json(id: "5")).
         to_return(status: 200, body: "", headers: {})
 
-      client.identify_customer_id(
+      client.identify(
         customer_id: "cio_5",
         id: "5"
       )
@@ -253,19 +252,10 @@ describe Customerio::Client do
         with(body: json(id: "5")).
         to_return(status: 200, body: "", headers: {})
 
-      client.identify_customer_id(
+      client.identify(
         customer_id: "customer@example.com",
         id: "5"
       )
-    end
-
-    it "requires a customer_id attribute" do
-      lambda { client.identify_customer_id() }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify_customer_id(customer_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      # None of these are customer_id
-      lambda { client.identify_customer_id(id: "5") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify_customer_id(cio_id: "cio_5") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify_customer_id(email: "customer@example.com") }.should raise_error(Customerio::Client::MissingIdAttributeError)
     end
   end
 


### PR DESCRIPTION
This is based on work by @jrbeck in https://github.com/customerio/customerio-ruby/pull/102 and @trwalzer in https://github.com/customerio/customerio-ruby/pull/88 and updated to work with the main branch. After some discussion within Customer.io Engineering, the functionality into the `identify` method, with a new `customer_id` attribute on that. It works in the same way as when it was a separate method.

These changes are necessary to allow identify operations where the person is identified by their email address, not `id` or `cio_id`. It updates `identify` so the identifier can be specified separately from the attributes, using the `customer_id` attribute. So you can e.g.: select a person based on their email address and set up their `id` and other attributes. See for example [this use-case](https://github.com/customerio/customerio-ruby/pull/102#issuecomment-1847408309).

Notes to CIO reviewers:

* The other client libraries seem to take the `customer_id` as their first parameter in the identify operation. I'm not sure why the Ruby client library does not. Supporting the `customer_id` attribute is bringing the Ruby client library.
* One **downside** of the approach in this PR is that it's no longer possible to create an attribute `customer_id` on the person.
* Perhaps we should break backwards compatibility and do a new version of the library that makes `identify` work like other client libraries - first arg is customer_id, attributes follow - so that `customer_id` can be created as a person attribute again.