### PR TITLE
Support GET requests in Base Client request_class

### DIFF
--- a/lib/customerio/base_client.rb
+++ b/lib/customerio/base_client.rb
@@ -72,6 +72,8 @@ module Customerio
         Net::HTTP::Put
       when :delete
         Net::HTTP::Delete
+      when :get
+        Net::HTTP::Get
       else
         raise InvalidRequest.new("Invalid request method #{method.inspect}")
       end

--- a/spec/base_client_spec.rb
+++ b/spec/base_client_spec.rb
@@ -45,6 +45,28 @@ describe Customerio::BaseClient do
     end
   end
 
+  describe "GET requests" do
+    describe "with a site ID and API key" do
+      it "sends a GET request with basic auth" do
+        stub_request(:get, api_uri('/some/path')).
+          with(headers: track_client_request_headers).
+          to_return(status: 200, body: "", headers: {})
+
+        track_client.request(:get, '/some/path', "")
+      end
+    end
+
+    describe "with an app key" do
+      it "sends a GET request with bearer token" do
+        stub_request(:get, api_uri('/some/path')).
+          with(headers: api_client_request_headers).
+          to_return(status: 200, body: "", headers: {})
+
+        api_client.request(:get, '/some/path', "")
+      end
+    end
+  end
+
   describe "#verify_response" do
     it "throws an error when the response isn't between 200 and 300" do
       stub_request(:put, api_uri('/some/path')).


### PR DESCRIPTION
Simple PR to allow sending GET requests since some API calls require it. For example, this allows api calls like GET Collections to work: 
```
@client.request_and_verify_response(:get, "/v1/api/collections")
```  

Issue was written up here:
https://github.com/customerio/customerio-ruby/issues/117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds `:get` support in request dispatch with minimal surface area change and no changes to auth, response handling, or payload serialization.
> 
> **Overview**
> Adds support for HTTP `GET` requests in `BaseClient#request_class`, allowing callers to use `request`/`request_and_verify_response` with `:get` instead of raising `InvalidRequest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b54adfc396f821eb964e345f05c4ac1f61e3da2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->