### PR TITLE
Support for transactional SMS API

### DIFF
--- a/lib/customerio.rb
+++ b/lib/customerio.rb
@@ -6,6 +6,7 @@ module Customerio
   require "customerio/client"
   require "customerio/requests/send_email_request"
   require "customerio/requests/send_push_request"
+  require "customerio/requests/send_sms_request"
   require "customerio/api"
   require "customerio/param_encoder"
 end

--- a/lib/customerio/api.rb
+++ b/lib/customerio/api.rb
@@ -41,6 +41,21 @@ module Customerio
       end
     end
 
+    def send_sms(req)
+      raise "request must be an instance of Customerio::SendSMSRequest" unless req.is_a?(Customerio::SendSMSRequest)
+      response = @client.request(:post, send_sms_path, req.message)
+
+      case response
+      when Net::HTTPSuccess then
+        JSON.parse(response.body)
+      when Net::HTTPBadRequest then
+        json = JSON.parse(response.body)
+        raise Customerio::InvalidResponse.new(response.code, json['meta']['error'], response)
+      else
+        raise InvalidResponse.new(response.code, response.body)
+      end
+    end
+
     private
 
     def send_email_path
@@ -49,6 +64,10 @@ module Customerio
 
     def send_push_path
       "/v1/send/push"
+    end
+
+    def send_sms_path
+      "/v1/send/sms"
     end
   end
 end

--- a/lib/customerio/requests/send_sms_request.rb
+++ b/lib/customerio/requests/send_sms_request.rb
@@ -1,0 +1,42 @@
+require 'base64'
+
+module Customerio
+  class SendSMSRequest
+    attr_reader :message
+
+    def initialize(opts)
+      @message = opts.delete_if { |field| invalid_field?(field) }
+      @message[:attachments] = {}
+      @message[:headers] = {}
+    end
+
+    def attach(name, data, encode: true)
+      raise "attachment #{name} already exists" if @message[:attachments].has_key?(name)
+      @message[:attachments][name] = encode ? Base64.strict_encode64(data) : data
+    end
+
+    private
+
+    REQUIRED_FIELDS = %i(identifiers)
+
+    OPTIONAL_FIELDS = %i(
+      transactional_message_id
+      message_data
+      from
+      disable_message_retention
+      send_to_unsubscribed
+      tracked
+      queue_draft
+      send_at
+      language
+    )
+
+    def invalid_field?(field)
+      !REQUIRED_FIELDS.include?(field) && !OPTIONAL_FIELDS.include?(field)
+    end
+
+    def encode(data)
+      Base64.strict_encode64(data)
+    end
+  end
+end

--- a/lib/customerio/requests/send_sms_request.rb
+++ b/lib/customerio/requests/send_sms_request.rb
@@ -23,6 +23,7 @@ module Customerio
       transactional_message_id
       message_data
       from
+      to
       disable_message_retention
       send_to_unsubscribed
       tracked

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -252,4 +252,63 @@ describe Customerio::APIClient do
       client.send_push(req).should eq({ "delivery_id" => 2 })
     end
   end
+
+  describe "#send_sms" do
+    it "sends a POST request to the /api/send/sms path" do
+      req = Customerio::SendSMSRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      stub_request(:post, api_uri('/v1/send/sms'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
+
+      client.send_sms(req).should eq({ "delivery_id" => 1 })
+    end
+
+    it "handles validation failures (400)" do
+      req = Customerio::SendSMSRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      err_json = { meta: { error: "example error" } }.to_json
+
+      stub_request(:post, api_uri('/v1/send/sms'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 400, body: err_json, headers: {})
+
+      lambda { client.send_sms(req) }.should(
+        raise_error(Customerio::InvalidResponse) { |error|
+          error.message.should eq "example error"
+          error.code.should eq "400"
+        }
+      )
+    end
+
+    it "handles other failures (5xx)" do
+      req = Customerio::SendSMSRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      stub_request(:post, api_uri('/v1/send/sms'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 500, body: "Server unavailable", headers: {})
+
+      lambda { client.send_sms(req) }.should(
+        raise_error(Customerio::InvalidResponse) { |error|
+          error.message.should eq "Server unavailable"
+          error.code.should eq "500"
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
Adds support for `send_sms` to send transactional SMS messages