### PR TITLE
Unpin addressable in customerio.gemspec

### DIFF
--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Customerio::VERSION
 
   gem.add_dependency('multi_json', "~> 1.0")
-  gem.add_dependency('addressable', '~> 2.8.0')
+  gem.add_dependency('addressable', '~> 2.8')
   gem.add_dependency('base64', '~> 0.3.0')
 
   gem.add_development_dependency('rake', '~> 10.5')


### PR DESCRIPTION
This PR unpins the specific dependency addressable, to allow 2.9+.

To use the gem from this branch, you can:

```ruby
gem "customerio", github: "olleolleolle/customerio-ruby", ref: "patch-1" # LOCKED: When https://github.com/customerio/customerio-ruby/pull/124 is merged and released, we can drop this and use the released version of customerio. # https://github.com/customerio/customerio-ruby
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency change limited to the gemspec; main risk is unexpected behavior changes if consumers resolve a newer `addressable` version.
> 
> **Overview**
> Relaxes the `addressable` runtime dependency constraint in `customerio.gemspec` from `~> 2.8.0` to `~> 2.8`, allowing bundlers to pick up newer compatible `addressable` releases (e.g., `2.9.x`) without changing any library code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1b2a0b28d8c35f44f853e31547a7593ba26d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->