### PR TITLE
Update to addressable 2.9

### DIFF
--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Customerio::VERSION
 
   gem.add_dependency('multi_json', "~> 1.0")
-  gem.add_dependency('addressable', '~> 2.8.0')
+  gem.add_dependency('addressable', '~> 2.9')
   gem.add_dependency('base64', '~> 0.3.0')
 
   gem.add_development_dependency('rake', '~> 10.5')


### PR DESCRIPTION
Update to addressable 2.9 to address https://nvd.nist.gov/vuln/detail/CVE-2026-35611

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; primary risk is unexpected URI parsing/encoding behavior differences from `addressable` 2.9 affecting request construction.
> 
> **Overview**
> Updates the runtime dependency on `addressable` from `~> 2.8.0` to `~> 2.9` in `customerio.gemspec` (intended to pick up fixes for a reported vulnerability). No application code changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3490b3d281299e47da544e073b4d129999044a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->