### PR TITLE
Bump SDK version

### DIFF
--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,3 +1,3 @@
 module Customerio
-  VERSION = "5.5.0"
+  VERSION = "5.5.1"
 end


### PR DESCRIPTION
Bump SDK version for https://github.com/customerio/customerio-ruby/pull/127

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only updates the gem version constant with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the Customer.io Ruby SDK/gem version from `5.5.0` to `5.5.1` by updating `Customerio::VERSION` in `lib/customerio/version.rb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce5c8daf9583a4edd31638017cf04006dfb1c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->