### PR TITLE
add support for sending transactional in-app messages

### DIFF
--- a/lib/customerio.rb
+++ b/lib/customerio.rb
@@ -8,6 +8,7 @@ module Customerio
   require "customerio/requests/send_push_request"
   require "customerio/requests/send_sms_request"
   require "customerio/requests/send_inbox_message_request"
+  require "customerio/requests/send_in_app_request"
   require "customerio/api"
   require "customerio/param_encoder"
 end

--- a/lib/customerio/api.rb
+++ b/lib/customerio/api.rb
@@ -71,6 +71,21 @@ module Customerio
       end
     end
 
+    def send_in_app(req)
+      raise "request must be an instance of Customerio::SendInAppRequest" unless req.is_a?(Customerio::SendInAppRequest)
+      response = @client.request(:post, send_in_app_path, req.message)
+
+      case response
+      when Net::HTTPSuccess then
+        JSON.parse(response.body)
+      when Net::HTTPBadRequest then
+        json = JSON.parse(response.body)
+        raise Customerio::InvalidResponse.new(response.code, json['meta']['error'], response)
+      else
+        raise InvalidResponse.new(response.code, response.body)
+      end
+    end
+
     private
 
     def send_email_path
@@ -87,6 +102,10 @@ module Customerio
 
     def send_inbox_message_path
       "/v1/send/inbox_message"
+    end
+
+    def send_in_app_path
+      "/v1/send/in_app"
     end
   end
 end

--- a/lib/customerio/requests/send_in_app_request.rb
+++ b/lib/customerio/requests/send_in_app_request.rb
@@ -1,0 +1,31 @@
+require 'base64'
+
+module Customerio
+  class SendInAppRequest
+    attr_reader :message
+
+    def initialize(opts)
+      @message = opts.delete_if { |field| invalid_field?(field) }
+    end
+
+    private
+
+    REQUIRED_FIELDS = %i(identifiers transactional_message_id)
+
+    OPTIONAL_FIELDS = %i(
+      message_data
+      disable_message_retention
+      queue_draft
+      send_at
+      language
+    )
+
+    def invalid_field?(field)
+      !REQUIRED_FIELDS.include?(field) && !OPTIONAL_FIELDS.include?(field)
+    end
+
+    def encode(data)
+      Base64.strict_encode64(data)
+    end
+  end
+end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -370,4 +370,63 @@ describe Customerio::APIClient do
       )
     end
   end
+
+  describe "#send_in_app" do
+    it "sends a POST request to the /api/send/in_app path" do
+      req = Customerio::SendInAppRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      stub_request(:post, api_uri('/v1/send/in_app'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
+
+      client.send_in_app(req).should eq({ "delivery_id" => 1 })
+    end
+
+    it "handles validation failures (400)" do
+      req = Customerio::SendInAppRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      err_json = { meta: { error: "example error" } }.to_json
+
+      stub_request(:post, api_uri('/v1/send/in_app'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 400, body: err_json, headers: {})
+
+      lambda { client.send_in_app(req) }.should(
+        raise_error(Customerio::InvalidResponse) { |error|
+          error.message.should eq "example error"
+          error.code.should eq "400"
+        }
+      )
+    end
+
+    it "handles other failures (5xx)" do
+      req = Customerio::SendInAppRequest.new(
+        identifiers: {
+          id: 'c1',
+        },
+        transactional_message_id: 1,
+      )
+
+      stub_request(:post, api_uri('/v1/send/in_app'))
+        .with(headers: request_headers, body: req.message)
+        .to_return(status: 500, body: "Server unavailable", headers: {})
+
+      lambda { client.send_in_app(req) }.should(
+        raise_error(Customerio::InvalidResponse) { |error|
+          error.message.should eq "Server unavailable"
+          error.code.should eq "500"
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
Adds `SendInAppRequest` and `APIClient#send_in_app` for the `POST /v1/send/in_app` endpoint. Follows the same pattern as the existing inbox message support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `send_in_app` request type and API client method following existing send patterns, with no changes to existing endpoints or shared request/response handling.
> 
> **Overview**
> Adds support for transactional *in-app* sends by introducing `SendInAppRequest` and wiring `APIClient#send_in_app` to call `POST /v1/send/in_app` with the same success/400/other error handling used by other send endpoints.
> 
> Updates the gem entrypoint (`lib/customerio.rb`) to require the new request type and adds API client specs covering success, validation (400), and server error (5xx) cases for `send_in_app`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d20eb654c87ccad27d5d93638fa3b2419cbed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->