### PR TITLE
Add explicit event options for track calls

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,9 @@
 ### Added
 - Added event options to `track`, `track_anonymous`, and `pageview` for setting top-level event `id`, `timestamp`, and `type` fields separately from event attributes.
 
+### Deprecated
+- Passing `timestamp` in event attributes to set the top-level event timestamp is deprecated. Pass `timestamp` as an event option instead.
+
 ## Customerio 5.4.0 - June 13, 2025
 ### Changed
 - Added `send_sms` to `APIClient` and `SendSMSRequest` to support sending transactional push notifications.

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## Customerio Next
+### Added
+- Added event options to `track`, `track_anonymous`, and `pageview` for setting top-level event `id`, `timestamp`, and `type` fields separately from event attributes.
+
 ## Customerio 5.4.0 - June 13, 2025
 ### Changed
 - Added `send_sms` to `APIClient` and `SendSMSRequest` to support sending transactional push notifications.

--- a/README.md
+++ b/README.md
@@ -188,15 +188,23 @@ encourage your customers to perform an action.
 # attributes (optional)  - any related information you'd like to attach to this
 #                          event. These attributes can be used in your triggers to control who should
 #                          receive the triggered email. You can set any number of data values.
+# event_options (optional) - top-level event properties. Supports :id, :timestamp, and :type.
 
 $customerio.track(5, "purchase", :type => "socks", :price => "13.99")
 ```
 
-**Note:** If you want to track events which occurred in the past, you can include a `timestamp` attribute
-(in seconds since the epoch), and we'll use that as the date the event occurred.
+Use event options when you need to set top-level event properties like `id`, `timestamp`, or `type`.
+The `id` option must be a ULID and is used to deduplicate events.
 
 ```ruby
-$customerio.track(5, "purchase", :type => "socks", :price => "13.99", :timestamp => 1365436200)
+$customerio.track(
+  5,
+  "purchase",
+  { :type => "socks", :price => "13.99" },
+  :id => "01G653VCS2Z4KQYQJCBVVB2CCW",
+  :timestamp => 1365436200,
+  :type => "event"
+)
 ```
 
 ### Tracking anonymous events
@@ -210,8 +218,20 @@ Anonymous events cannot trigger campaigns by themselves. To trigger a campaign, 
 # anonymous_id (required, nullable) - the id representing the unknown person.
 # name (required)                   - the name of the event you want to track.
 # attributes (optional)             - related information you want to attach to the event.
+# event_options (optional)          - top-level event properties. Supports :id, :timestamp, and :type.
 
 $customerio.track_anonymous(anonymous_id, "product_view", :type => "socks" )
+```
+
+```ruby
+$customerio.track_anonymous(
+  anonymous_id,
+  "product_view",
+  { :type => "socks" },
+  :id => "01G653VCS2Z4KQYQJCBVVB2CCW",
+  :timestamp => 1365436200,
+  :type => "screen"
+)
 ```
 
 Use the `recipient` attribute to specify the email address to send the messages to. [See our documentation on how to use anonymous events for more details](https://customer.io/docs/invite-emails/).

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ $customerio.track(5, "purchase", :type => "socks", :price => "13.99")
 
 Use event options when you need to set top-level event properties like `id`, `timestamp`, or `type`.
 The `id` option must be a ULID and is used to deduplicate events.
+Passing `:timestamp` in event attributes to set the top-level event timestamp is deprecated. It still
+works for now, but emits a warning. Pass `:timestamp` as an event option instead.
 
 ```ruby
 $customerio.track(

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -61,20 +61,36 @@ module Customerio
       raise ParamError, "customer_id must be a non-empty string" if empty?(customer_id)
       raise ParamError, "event_name must be a non-empty string" if empty?(event_name)
 
-      create_customer_event(customer_id, event_name, attributes, event_options)
+      create_event(
+        path: customer_events_path(customer_id),
+        event_name: event_name,
+        attributes: attributes,
+        event_options: event_options
+      )
     end
 
     def pageview(customer_id, page, attributes = {}, event_options = {})
       raise ParamError, "customer_id must be a non-empty string" if empty?(customer_id)
       raise ParamError, "page must be a non-empty string" if empty?(page)
 
-      create_pageview_event(customer_id, page, attributes, event_options)
+      create_event(
+        path: customer_events_path(customer_id),
+        event_name: page,
+        attributes: attributes,
+        event_options: event_options.merge(type: EVENT_TYPE_PAGE)
+      )
     end
 
     def track_anonymous(anonymous_id, event_name, attributes = {}, event_options = {})
       raise ParamError, "event_name must be a non-empty string" if empty?(event_name)
 
-      create_anonymous_event(anonymous_id, event_name, attributes, event_options)
+      create_event(
+        path: "/api/v1/events",
+        event_name: event_name,
+        anonymous_id: anonymous_id,
+        attributes: attributes,
+        event_options: event_options
+      )
     end
 
     def add_device(customer_id, device_id, platform, data = {})
@@ -149,6 +165,10 @@ module Customerio
       "/api/v1/customers/#{escape(id)}"
     end
 
+    def customer_events_path(customer_id)
+      "#{customer_path(customer_id)}/events"
+    end
+
     def suppress_path(customer_id)
       "/api/v1/customers/#{escape(customer_id)}/suppress"
     end
@@ -195,42 +215,14 @@ module Customerio
       @client.request_and_verify_response(:put, url, attributes)
     end
 
-    def create_customer_event(customer_id, event_name, attributes = {}, event_options = {})
-      create_event(
-        url: "#{customer_path(customer_id)}/events",
-        event_name: event_name,
-        attributes: attributes,
-        event_options: event_options
-      )
-    end
-
-    def create_anonymous_event(anonymous_id, event_name, attributes = {}, event_options = {})
-      create_event(
-        url: "/api/v1/events",
-        event_name: event_name,
-        anonymous_id: anonymous_id,
-        attributes: attributes,
-        event_options: event_options
-      )
-    end
-
-    def create_pageview_event(customer_id, page, attributes = {}, event_options = {})
-      create_event(
-        url: "#{customer_path(customer_id)}/events",
-        event_name: page,
-        attributes: attributes,
-        event_options: event_options.merge(type: EVENT_TYPE_PAGE)
-      )
-    end
-
-    def create_event(url:, event_name:, anonymous_id: nil, attributes: {}, event_options: {})
+    def create_event(path:, event_name:, anonymous_id: nil, attributes: {}, event_options: {})
       event_options = symbolize_keys(event_options)
       body = { name: event_name, data: attributes }
       add_event_options(body, event_options)
       body[:timestamp] = attributes[:timestamp] if !body.key?(:timestamp) && valid_timestamp?(attributes[:timestamp])
       body[:anonymous_id] = anonymous_id unless empty?(anonymous_id)
 
-      @client.request_and_verify_response(:post, url, body)
+      @client.request_and_verify_response(:post, path, body)
     end
 
     def add_event_options(body, event_options)

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -14,6 +14,11 @@ module Customerio
     PUSH_CONVERTED = "converted"
     PUSH_DELIVERED = "delivered"
 
+    EVENT_TYPE_EVENT = "event"
+    EVENT_TYPE_PAGE = "page"
+    EVENT_TYPE_SCREEN = "screen"
+
+    VALID_EVENT_TYPES = [EVENT_TYPE_EVENT, EVENT_TYPE_PAGE, EVENT_TYPE_SCREEN].freeze
     VALID_PUSH_EVENTS = [PUSH_OPENED, PUSH_CONVERTED, PUSH_DELIVERED].freeze
 
     class MissingIdAttributeError < StandardError; end
@@ -52,24 +57,24 @@ module Customerio
       @client.request_and_verify_response(:post, unsuppress_path(customer_id))
     end
 
-    def track(customer_id, event_name, attributes = {})
+    def track(customer_id, event_name, attributes = {}, event_options = {})
       raise ParamError, "customer_id must be a non-empty string" if empty?(customer_id)
       raise ParamError, "event_name must be a non-empty string" if empty?(event_name)
 
-      create_customer_event(customer_id, event_name, attributes)
+      create_customer_event(customer_id, event_name, attributes, event_options)
     end
 
-    def pageview(customer_id, page, attributes = {})
+    def pageview(customer_id, page, attributes = {}, event_options = {})
       raise ParamError, "customer_id must be a non-empty string" if empty?(customer_id)
       raise ParamError, "page must be a non-empty string" if empty?(page)
 
-      create_pageview_event(customer_id, page, attributes)
+      create_pageview_event(customer_id, page, attributes, event_options)
     end
 
-    def track_anonymous(anonymous_id, event_name, attributes = {})
+    def track_anonymous(anonymous_id, event_name, attributes = {}, event_options = {})
       raise ParamError, "event_name must be a non-empty string" if empty?(event_name)
 
-      create_anonymous_event(anonymous_id, event_name, attributes)
+      create_anonymous_event(anonymous_id, event_name, attributes, event_options)
     end
 
     def add_device(customer_id, device_id, platform, data = {})
@@ -190,39 +195,56 @@ module Customerio
       @client.request_and_verify_response(:put, url, attributes)
     end
 
-    def create_customer_event(customer_id, event_name, attributes = {})
+    def create_customer_event(customer_id, event_name, attributes = {}, event_options = {})
       create_event(
         url: "#{customer_path(customer_id)}/events",
         event_name: event_name,
-        attributes: attributes
+        attributes: attributes,
+        event_options: event_options
       )
     end
 
-    def create_anonymous_event(anonymous_id, event_name, attributes = {})
+    def create_anonymous_event(anonymous_id, event_name, attributes = {}, event_options = {})
       create_event(
         url: "/api/v1/events",
         event_name: event_name,
         anonymous_id: anonymous_id,
-        attributes: attributes
+        attributes: attributes,
+        event_options: event_options
       )
     end
 
-    def create_pageview_event(customer_id, page, attributes = {})
+    def create_pageview_event(customer_id, page, attributes = {}, event_options = {})
       create_event(
         url: "#{customer_path(customer_id)}/events",
-        event_type: "page",
         event_name: page,
-        attributes: attributes
+        attributes: attributes,
+        event_options: event_options.merge(type: EVENT_TYPE_PAGE)
       )
     end
 
-    def create_event(url:, event_name:, anonymous_id: nil, event_type: nil, attributes: {})
+    def create_event(url:, event_name:, anonymous_id: nil, attributes: {}, event_options: {})
+      event_options = symbolize_keys(event_options)
       body = { name: event_name, data: attributes }
-      body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
+      add_event_options(body, event_options)
+      body[:timestamp] = attributes[:timestamp] if !body.key?(:timestamp) && valid_timestamp?(attributes[:timestamp])
       body[:anonymous_id] = anonymous_id unless empty?(anonymous_id)
-      body[:type] = event_type unless empty?(event_type)
 
       @client.request_and_verify_response(:post, url, body)
+    end
+
+    def add_event_options(body, event_options)
+      body[:id] = event_options[:id] if valid_event_id?(event_options[:id])
+      body[:timestamp] = event_options[:timestamp] if valid_timestamp?(event_options[:timestamp])
+      body[:type] = event_options[:type] if valid_event_type?(event_options[:type])
+    end
+
+    def valid_event_id?(id)
+      id.is_a?(String) && !empty?(id)
+    end
+
+    def valid_event_type?(event_type)
+      VALID_EVENT_TYPES.include?(event_type)
     end
 
     def valid_timestamp?(timestamp)

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -20,6 +20,9 @@ module Customerio
 
     VALID_EVENT_TYPES = [EVENT_TYPE_EVENT, EVENT_TYPE_PAGE, EVENT_TYPE_SCREEN].freeze
     VALID_PUSH_EVENTS = [PUSH_OPENED, PUSH_CONVERTED, PUSH_DELIVERED].freeze
+    DEPRECATED_ATTRIBUTE_TIMESTAMP_WARNING = "DEPRECATION: Passing :timestamp in event attributes to set " \
+                                             "the top-level event timestamp is deprecated. Pass :timestamp " \
+                                             "as an event option instead."
 
     class MissingIdAttributeError < StandardError; end
     class ParamError < StandardError; end
@@ -219,7 +222,7 @@ module Customerio
       event_options = symbolize_keys(event_options)
       body = { name: event_name, data: attributes }
       add_event_options(body, event_options)
-      body[:timestamp] = attributes[:timestamp] if !body.key?(:timestamp) && valid_timestamp?(attributes[:timestamp])
+      add_deprecated_attribute_timestamp(body, attributes)
       body[:anonymous_id] = anonymous_id unless empty?(anonymous_id)
 
       @client.request_and_verify_response(:post, path, body)
@@ -229,6 +232,20 @@ module Customerio
       body[:id] = event_options[:id] if valid_event_id?(event_options[:id])
       body[:timestamp] = event_options[:timestamp] if valid_timestamp?(event_options[:timestamp])
       body[:type] = event_options[:type] if valid_event_type?(event_options[:type])
+    end
+
+    def add_deprecated_attribute_timestamp(body, attributes)
+      return if body.key?(:timestamp) || !valid_timestamp?(attributes[:timestamp])
+
+      warn_deprecated_attribute_timestamp
+      body[:timestamp] = attributes[:timestamp]
+    end
+
+    def warn_deprecated_attribute_timestamp
+      return if self.class.instance_variable_get(:@attribute_timestamp_deprecation_warning_emitted)
+
+      warn(DEPRECATED_ATTRIBUTE_TIMESTAMP_WARNING)
+      self.class.instance_variable_set(:@attribute_timestamp_deprecation_warning_emitted, true)
     end
 
     def valid_event_id?(id)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -322,6 +322,29 @@ describe Customerio::Client do
 
       client.pageview(5, "http://customer.io")
     end
+
+    it "allows sending top-level event options" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "http://customer.io",
+          data: {
+            title: "Home"
+          },
+          id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+          timestamp: 1561231234,
+          type: "page"
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.pageview(
+        5,
+        "http://customer.io",
+        { title: "Home" },
+        id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+        timestamp: 1561231234,
+        type: "screen"
+      )
+    end
   end
 
   describe "#track" do
@@ -418,6 +441,78 @@ describe Customerio::Client do
       client.track(5, "purchase", type: "socks", price: "13.99", timestamp: 1561231234)
     end
 
+    it "allows sending top-level event options" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            type: "socks",
+            price: "13.99",
+            id: "product-123",
+            timestamp: 1561231000
+          },
+          id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+          timestamp: 1561231234,
+          type: "screen"
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(
+        5,
+        "purchase",
+        { type: "socks", price: "13.99", id: "product-123", timestamp: 1561231000 },
+        id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+        timestamp: 1561231234,
+        type: "screen"
+      )
+    end
+
+    it "doesn't promote event id from attributes" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            type: "socks",
+            id: "01G653VCS2Z4KQYQJCBVVB2CCW"
+          }
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(5, "purchase", type: "socks", id: "01G653VCS2Z4KQYQJCBVVB2CCW")
+    end
+
+    it "accepts event options with string keys" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {},
+          id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+          timestamp: 1561231234,
+          type: "event"
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(
+        5,
+        "purchase",
+        {},
+        "id" => "01G653VCS2Z4KQYQJCBVVB2CCW",
+        "timestamp" => 1561231234,
+        "type" => "event"
+      )
+    end
+
+    it "doesn't send invalid event options" do
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {}
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.track(5, "purchase", {}, id: "", timestamp: 1561231234000, type: "mobile")
+    end
+
     it "doesn't send timestamp if timestamp is in milliseconds" do
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
         with(body: json({
@@ -507,6 +602,31 @@ describe Customerio::Client do
           to_return(status: 200, body: "", headers: {})
 
         client.track_anonymous(anon_id, "purchase", type: "socks", price: "13.99", timestamp: 1561231234)
+      end
+
+      it "allows sending top-level event options" do
+        stub_request(:post, api_uri('/api/v1/events')).
+          with(body: {
+            anonymous_id: anon_id,
+            name: "purchase",
+            data: {
+              type: "socks",
+              price: "13.99"
+            },
+            id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+            timestamp: 1561231234,
+            type: "screen"
+          }).
+          to_return(status: 200, body: "", headers: {})
+
+        client.track_anonymous(
+          anon_id,
+          "purchase",
+          { type: "socks", price: "13.99" },
+          id: "01G653VCS2Z4KQYQJCBVVB2CCW",
+          timestamp: 1561231234,
+          type: "screen"
+        )
       end
 
       it "raises an error if POST doesn't return a 2xx response code" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -22,6 +22,10 @@ describe Customerio::Client do
     MultiJson.dump(data)
   end
 
+  def reset_attribute_timestamp_deprecation_warning
+    Customerio::Client.instance_variable_set(:@attribute_timestamp_deprecation_warning_emitted, false)
+  end
+
   it "the base client is initialised with the correct values when no region is passed in" do
     site_id = "SITE_ID"
     api_key = "API_KEY"
@@ -426,6 +430,9 @@ describe Customerio::Client do
     end
 
     it "allows sending of a timestamp" do
+      reset_attribute_timestamp_deprecation_warning
+      expect(client).to receive(:warn).with(Customerio::Client::DEPRECATED_ATTRIBUTE_TIMESTAMP_WARNING)
+
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
         with(body: json({
           name: "purchase",
@@ -442,6 +449,8 @@ describe Customerio::Client do
     end
 
     it "allows sending top-level event options" do
+      expect(client).not_to receive(:warn)
+
       stub_request(:post, api_uri('/api/v1/customers/5/events')).
         with(body: json({
           name: "purchase",
@@ -465,6 +474,25 @@ describe Customerio::Client do
         timestamp: 1561231234,
         type: "screen"
       )
+    end
+
+    it "only warns once when promoting timestamps from attributes" do
+      reset_attribute_timestamp_deprecation_warning
+      expect(client).to receive(:warn).with(Customerio::Client::DEPRECATED_ATTRIBUTE_TIMESTAMP_WARNING).once
+
+      stub_request(:post, api_uri('/api/v1/customers/5/events')).
+        with(body: json({
+          name: "purchase",
+          data: {
+            timestamp: 1561231234
+          },
+          timestamp: 1561231234
+        })).
+        to_return(status: 200, body: "", headers: {})
+
+      2.times do
+        client.track(5, "purchase", timestamp: 1561231234)
+      end
     end
 
     it "doesn't promote event id from attributes" do
@@ -588,6 +616,9 @@ describe Customerio::Client do
       end
 
       it "allows sending of a timestamp" do
+        reset_attribute_timestamp_deprecation_warning
+        expect(client).to receive(:warn).with(Customerio::Client::DEPRECATED_ATTRIBUTE_TIMESTAMP_WARNING)
+
         stub_request(:post, api_uri('/api/v1/events')).
           with(body: {
             anonymous_id: anon_id,


### PR DESCRIPTION
## Summary
- add an explicit event options hash to track, track_anonymous, and pageview
- support top-level event id, timestamp, and type without pulling them from event attributes
- document the new API and add changelog coverage

## Testing
- env BUNDLE_PATH=/Users/stephen/code/clients/customerio-ruby/vendor/bundle XDG_CACHE_HOME=/private/tmp/rubocop-cache /opt/homebrew/opt/ruby/bin/bundle exec rake

This is intended as the Ruby equivalent of go-customerio's track option pattern and avoids overloading data attributes like id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API for `track`, `pageview`, and `track_anonymous` changes to accept an additional `event_options` hash and alters how top-level event fields are set, which may affect existing integrations relying on attribute-based timestamps or event type behavior.
> 
> **Overview**
> Adds an explicit `event_options` parameter to `Customerio::Client#track`, `#track_anonymous`, and `#pageview`, allowing callers to set top-level event `id`, `timestamp`, and `type` without overloading event `data` attributes (with validation for allowed event types).
> 
> Deprecates using `:timestamp` inside event attributes to set the top-level timestamp: the client will still promote it for now but emits a one-time warning. Updates README and CHANGELOG accordingly, and expands specs to cover event options, validation, and deprecation warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42921420cee029dce369fc5623f14cbb84434ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->