### PR TITLE
Document timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ $customerio = Customerio::Client.new("YOUR SITE ID", "YOUR API SECRET KEY", regi
 
 `region` is optional and takes one of two values—`US` or `EU`. If you do not specify your region, we assume that your account is based in the US (`US`). If your account is based in the EU and you do not provide the correct region (`EU`), we'll route requests to our EU data centers accordingly, however this may cause data to be logged in the US. 
 
+#### Timeouts
+
+Both clients accept a `timeout` option (in seconds) that controls the HTTP connect and read timeouts. The default is 10 seconds.
+
+```ruby
+# Track API client with a 3-second timeout
+$customerio = Customerio::Client.new("YOUR SITE ID", "YOUR API SECRET KEY", timeout: 3)
+
+# Transactional API client with a 3-second timeout
+client = Customerio::APIClient.new("your API key", timeout: 3)
+```
+
+When a request exceeds the timeout, Ruby raises `Net::OpenTimeout` (connection phase) or `Net::ReadTimeout` (waiting for response). You can rescue both:
+
+```ruby
+begin
+  $customerio.identify(id: 5, email: "person@example.com")
+rescue Net::OpenTimeout, Net::ReadTimeout => e
+  # handle timeout
+end
+```
+
 ### Identify logged in customers
 
 Tracking data of logged in customers is a key part of [Customer.io](https://customer.io). In order to


### PR DESCRIPTION
## Summary
- Document the existing timeout option for both Client and APIClient in the README
- Include error handling guidance (Net::OpenTimeout / Net::ReadTimeout)

Fixes #105

## Test plan
- [ ] README renders correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change describing an existing `timeout` configuration and related Ruby timeout exceptions; no runtime behavior changes.
> 
> **Overview**
> Adds a new **Timeouts** section to `README.md` documenting the existing `timeout` option for both `Customerio::Client` and `Customerio::APIClient`, including example configuration.
> 
> Also documents how to handle request timeouts by rescuing `Net::OpenTimeout` and `Net::ReadTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba9572d3651f24fdafadb5f840594434b92f21b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->