### PR TITLE
Add batch API support (Track v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,35 @@ Start tracking events and identifies again for a previously suppressed customer.
 $customerio.unsuppress(5)
 ```
 
+### Batch operations
+
+You can send up to 500KB of operations in a single request using the [Track v2 batch endpoint](https://customer.io/docs/api/track/#tag/Track-v2/operation/batch). Each operation can identify, track events, or delete people and objects.
+
+```ruby
+$customerio.batch([
+  {
+    type: "person",
+    identifiers: { id: "42" },
+    action: "identify",
+    attributes: { first_name: "Jane", plan: "premium" },
+  },
+  {
+    type: "person",
+    identifiers: { id: "42" },
+    action: "event",
+    name: "purchase",
+    data: { amount: 99 },
+  },
+  {
+    type: "person",
+    identifiers: { id: "99" },
+    action: "delete",
+  },
+])
+```
+
+See the [Track v2 API docs](https://customer.io/docs/api/track/#tag/Track-v2/operation/batch) for the full list of supported actions and fields.
+
 ### Send Transactional Messages
 
 To use the Customer.io [Transactional API](https://customer.io/docs/transactional-api), create an instance of the API client using an [app key](https://customer.io/docs/managing-credentials#app-api-keys) and create a request object of your message type.

--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -125,6 +125,12 @@ module Customerio
       @client.request_and_verify_response(:post, merge_customers_path, body)
     end
 
+    def batch(operations)
+      raise ParamError, "operations must be a non-empty array" unless operations.is_a?(Array) && !operations.empty?
+
+      @client.request_and_verify_response(:post, batch_path, batch: operations)
+    end
+
     private
 
     def escape(val)
@@ -158,6 +164,10 @@ module Customerio
 
     def merge_customers_path
       "/api/v1/merge_customers"
+    end
+
+    def batch_path
+      "/api/v2/batch"
     end
 
     def create_or_update(attributes = {})

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -715,4 +715,77 @@ describe Customerio::Client do
       client.merge_customers(Customerio::IdentifierType::ID, "ID1", Customerio::IdentifierType::EMAIL, "hello@company.com")
     end
   end
+
+  describe "#batch" do
+    it "sends a POST request to the batch API with mixed operations" do
+      operations = [
+        {
+          type: "person",
+          identifiers: { id: "42" },
+          action: "identify",
+          attributes: { first_name: "Jane", plan: "premium" }
+        },
+        {
+          type: "person",
+          identifiers: { id: "42" },
+          action: "event",
+          name: "purchase",
+          data: { amount: 99 }
+        },
+        {
+          type: "person",
+          identifiers: { id: "99" },
+          action: "delete"
+        }
+      ]
+
+      stub_request(:post, api_uri('/api/v2/batch')).
+        with(body: json({ batch: operations })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.batch(operations)
+    end
+
+    it "sends object operations" do
+      operations = [
+        {
+          type: "object",
+          identifiers: { object_type_id: "1", object_id: "acme" },
+          action: "identify",
+          attributes: { name: "Acme Corp" }
+        }
+      ]
+
+      stub_request(:post, api_uri('/api/v2/batch')).
+        with(body: json({ batch: operations })).
+        to_return(status: 200, body: "", headers: {})
+
+      client.batch(operations)
+    end
+
+    it "raises an error when operations is empty" do
+      lambda { client.batch([]) }.should raise_error(Customerio::Client::ParamError)
+    end
+
+    it "raises an error when operations is not an array" do
+      lambda { client.batch("not an array") }.should raise_error(Customerio::Client::ParamError)
+    end
+
+    it "raises an error on non-2xx response" do
+      operations = [
+        {
+          type: "person",
+          identifiers: { id: "42" },
+          action: "identify",
+          attributes: { first_name: "Jane" }
+        }
+      ]
+
+      stub_request(:post, api_uri('/api/v2/batch')).
+        with(body: json({ batch: operations })).
+        to_return(status: 400, body: "Bad request", headers: {})
+
+      lambda { client.batch(operations) }.should raise_error(Customerio::InvalidResponse)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `Client#batch` for `POST /api/v2/batch` (Track v2 API)
- Accepts an array of operations — identify, event, delete, etc. for people and objects
- Uses existing Track client auth (site_id + api_key)
- Pass-through design: no client-side validation of individual operations, API handles that

Closes #106. Requested by multiple users over 18+ months.

## Test plan
- [ ] CI passes on Ruby 3.3, 3.4, 4.0, head
- [ ] Mixed operations sent correctly to `/api/v2/batch`
- [ ] Object operations work
- [ ] Empty/non-array input rejected
- [ ] Non-2xx responses raise `InvalidResponse`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new API wrapper method and documentation/tests for posting batch operations; behavior is straightforward and limited to a new endpoint call with basic input validation.
> 
> **Overview**
> Adds `Client#batch` to send Track v2 batch operations via `POST /api/v2/batch`, accepting an array of operations and rejecting empty/non-array inputs.
> 
> Updates the README with usage examples for batching identify/event/delete operations, and adds specs covering mixed person/object batches plus error handling for invalid inputs and non-2xx responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3745567c35a95f57a0e1c8a36d55962ce1e4782d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->