### PR TITLE
Add RubyGems publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to RubyGems
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment: rubygems
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Build gem
+        run: gem build customerio.gemspec
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,12 @@
 name: Publish to RubyGems
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -16,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,5 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Build gem
-        run: gem build customerio.gemspec
-
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,14 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
+      - name: Verify tag matches gem version
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          version=$(ruby -r ./lib/customerio/version -e "puts Customerio::VERSION")
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Tag v$tag does not match Customerio::VERSION ($version)"
+            exit 1
+          fi
+
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to publish gem to RubyGems on release creation
- Uses OIDC trusted publishing (no API keys/secrets needed)
- Mirrors the publish workflow pattern from customerio-python

## Setup required
1. **rubygems.org**: Add trusted publisher under gem settings — repo `customerio/customerio-ruby`, workflow `publish.yml`, environment `rubygems`
2. **GitHub**: Create `rubygems` environment in repo Settings → Environments

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Configure trusted publisher on rubygems.org
- [ ] Create GitHub `rubygems` environment
- [ ] Test with a release publish

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an automated release pipeline that can publish the gem to RubyGems using OIDC and write repo contents, so misconfiguration could publish unintended versions or affect release integrity.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/publish.yml`) that runs on `v*` tag pushes to build and publish the gem to RubyGems via `rubygems/release-gem@v1` using OIDC (`id-token: write`).
> 
> The workflow includes a guard step that fails the run if the pushed tag version does not match `Customerio::VERSION` before publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d690840ee71c0783a1a576ad560dd41b923aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->