### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Customerio
-  VERSION = "5.6.0"
+  VERSION = "6.0.0"
 end


### PR DESCRIPTION
## Summary
- Bump `Customerio::VERSION` from 5.6.0 to 6.0.0

## Release
After merge, push tag `v6.0.0` to trigger publish workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the library version constant and does not change runtime behavior. Risk is limited to downstream consumers interpreting the major version bump as a breaking release.
> 
> **Overview**
> Bumps `Customerio::VERSION` from `5.6.0` to `6.0.0` in `lib/customerio/version.rb` to prepare the `v6.0.0` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2847346dedeefcd21797bd62f5b8fa00d42048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->