### PR TITLE
Raise on invalid timestamps instead of silently dropping

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -141,6 +141,7 @@ module Customerio
       raise ParamError, "delivery_id must be a non-empty string" if empty?(attributes[:delivery_id])
 
       body = { delivery_id: attributes[:delivery_id], metric: metric_name }
+      validate_timestamp!(attributes[:timestamp])
       body[:timestamp] = attributes[:timestamp] if valid_timestamp?(attributes[:timestamp])
       body[:recipient] = attributes[:recipient] unless empty?(attributes[:recipient])
       body[:reason] = attributes[:reason] unless empty?(attributes[:reason])
@@ -271,8 +272,11 @@ module Customerio
 
     def create_event(url:, event_name:, anonymous_id: nil, event_type: nil, attributes: {}, id: nil, timestamp: nil) # rubocop:disable Metrics/ParameterLists
       body = { name: event_name, data: attributes }
-      body[:timestamp] = timestamp if valid_timestamp?(timestamp)
-      body[:timestamp] = attributes[:timestamp] if body[:timestamp].nil? && valid_timestamp?(attributes[:timestamp])
+      effective_timestamp = timestamp || attributes[:timestamp]
+      if effective_timestamp
+        validate_timestamp!(effective_timestamp)
+        body[:timestamp] = effective_timestamp
+      end
       body[:anonymous_id] = anonymous_id unless empty?(anonymous_id)
       body[:type] = event_type unless empty?(event_type)
       body[:id] = id unless empty?(id)
@@ -282,6 +286,13 @@ module Customerio
 
     def valid_timestamp?(timestamp)
       timestamp.is_a?(Integer) && timestamp > 999_999_999 && timestamp < 100_000_000_000
+    end
+
+    def validate_timestamp!(timestamp)
+      return if timestamp.nil?
+      return if valid_timestamp?(timestamp)
+
+      raise ParamError, "timestamp must be a valid integer (seconds since epoch, 10-digit range)"
     end
 
     def empty?(val)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -433,49 +433,22 @@ describe Customerio::Client do
       client.track(5, "purchase", {type: "socks", price: "13.99", timestamp: 1561231234})
     end
 
-    it "doesn't send timestamp if timestamp is in milliseconds" do
-      stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(body: json({
-          name: "purchase",
-          data: {
-            type: "socks",
-            price: "13.99"
-          }
-        })).
-        to_return(status: 200, body: "", headers: {})
-
-      client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: 1561231234000)
+    it "raises an error if timestamp is in milliseconds" do
+      lambda {
+        client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: 1561231234000)
+      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
-    it "doesn't send timestamp if timestamp is a date" do
-      date = Time.now
-
-      stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(body: {
-          name: "purchase",
-          data: {
-            type: "socks",
-            price: "13.99"
-          }
-        }).
-        to_return(status: 200, body: "", headers: {})
-
-      client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: date)
+    it "raises an error if timestamp is a date" do
+      lambda {
+        client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: Time.now)
+      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
-    it "doesn't send timestamp if timestamp isn't an integer" do
-      stub_request(:post, api_uri('/api/v1/customers/5/events')).
-        with(body: json({
-          name: "purchase",
-          data: {
-            type: "socks",
-            price: "13.99"
-          }
-        })).
-
-        to_return(status: 200, body: "", headers: {})
-
-      client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: "Hello world")
+    it "raises an error if timestamp isn't an integer" do
+      lambda {
+        client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: "Hello world")
+      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "sends an event id for deduplication when provided" do
@@ -845,22 +818,13 @@ describe Customerio::Client do
       })
     end
 
-    it "omits timestamp when not a valid integer" do
-      stub_request(:post, api_uri("/api/v1/metrics")).
-        with(
-          :body => json({
-            :delivery_id => "abc123",
-            :metric => "delivered"
-          }),
-          :headers => {
-            "Content-Type" => "application/json"
-          }).
-        to_return(:status => 200, :body => "", :headers => {})
-
-      client.track_delivery_metric("delivered", {
-        :delivery_id => "abc123",
-        :timestamp => "not-a-timestamp"
-      })
+    it "raises an error when timestamp is not a valid integer" do
+      lambda {
+        client.track_delivery_metric("delivered", {
+          :delivery_id => "abc123",
+          :timestamp => "not-a-timestamp"
+        })
+      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "should raise if metric_name is invalid" do


### PR DESCRIPTION
## Summary
- `track()`, `track_anonymous()`, and `track_delivery_metric()` previously silently discarded invalid timestamps (milliseconds, strings, Time objects) — now they raise `ParamError` with a descriptive message
- Consistent with `track_push_notification_event` which already raised on invalid timestamps
- Added `validate_timestamp!` private helper to centralize validation

## Breaking change
Users relying on silent discard of invalid timestamps will now get `Customerio::Client::ParamError`. This is intentional — silent data loss is worse than a loud error.

## Test plan
- [x] Updated 3 tests in `#track` from "silently drops" to "raises ParamError"
- [x] Updated 1 test in `#track_delivery_metric` from "silently drops" to "raises ParamError"
- [x] All 130 examples pass
- [x] RuboCop clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes public client behavior by turning previously ignored invalid `timestamp` inputs into hard errors, which is a breaking change for callers. Logic is localized to timestamp validation but affects common tracking methods.
> 
> **Overview**
> Stops silently dropping invalid `timestamp` values in `track`/`track_anonymous` event creation and `track_delivery_metric`; invalid timestamps now raise `Customerio::Client::ParamError`.
> 
> Adds a shared `validate_timestamp!` helper and updates event creation to prefer `timestamp` keyword arg over `attributes[:timestamp]` while validating the chosen value, with specs updated to expect errors for milliseconds, non-integers, and `Time` objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a85e2edc596a61d3ced3dfe072b1d004f341f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->