### PR TITLE
Modernize RSpec tests to use expect syntax exclusively

### DIFF
--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -76,7 +76,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
 
-      client.send_email(req).should eq({ "delivery_id" => 1 })
+      expect(client.send_email(req)).to eq({ "delivery_id" => 1 })
     end
 
     it "handles validation failures (400)" do
@@ -93,10 +93,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.send_email(req) }.should(
+      expect { client.send_email(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -113,10 +113,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.send_email(req) }.should(
+      expect { client.send_email(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end
@@ -130,7 +130,7 @@ describe Customerio::APIClient do
       )
 
       req.attach('test', content, encode: false)
-      req.message[:attachments]['test'].should eq content
+      expect(req.message[:attachments]['test']).to eq(content)
 
       stub_request(:post, api_uri('/v1/send/email'))
         .with(headers: request_headers, body: req.message)
@@ -148,7 +148,7 @@ describe Customerio::APIClient do
       )
 
       req.attach('test', content)
-      req.message[:attachments]['test'].should eq Base64.strict_encode64(content)
+      expect(req.message[:attachments]['test']).to eq(Base64.strict_encode64(content))
 
       stub_request(:post, api_uri('/v1/send/email'))
         .with(headers: request_headers, body: req.message)
@@ -165,8 +165,8 @@ describe Customerio::APIClient do
 
       req.attach('test', 'test-content')
 
-      lambda { req.attach('test', '') }.should raise_error(/attachment test already exists/)
-      req.message[:attachments].should eq({ "test" => Base64.strict_encode64("test-content") })
+      expect { req.attach('test', '') }.to raise_error(/attachment test already exists/)
+      expect(req.message[:attachments]).to eq({ "test" => Base64.strict_encode64("test-content") })
     end
   end
 
@@ -183,7 +183,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
 
-      client.send_push(req).should eq({ "delivery_id" => 1 })
+      expect(client.send_push(req)).to eq({ "delivery_id" => 1 })
     end
 
     it "handles validation failures (400)" do
@@ -200,10 +200,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.send_push(req) }.should(
+      expect { client.send_push(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -220,10 +220,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.send_push(req) }.should(
+      expect { client.send_push(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end
@@ -240,7 +240,7 @@ describe Customerio::APIClient do
         }
       )
 
-      req.message[:custom_device].should eq({
+      expect(req.message[:custom_device]).to eq({
         platform: 'ios',
         token: 'sample-token',
       })
@@ -249,7 +249,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 2 }.to_json, headers: {})
 
-      client.send_push(req).should eq({ "delivery_id" => 2 })
+      expect(client.send_push(req)).to eq({ "delivery_id" => 2 })
     end
   end
 
@@ -266,7 +266,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
 
-      client.send_sms(req).should eq({ "delivery_id" => 1 })
+      expect(client.send_sms(req)).to eq({ "delivery_id" => 1 })
     end
 
     it "handles validation failures (400)" do
@@ -283,10 +283,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.send_sms(req) }.should(
+      expect { client.send_sms(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -303,10 +303,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.send_sms(req) }.should(
+      expect { client.send_sms(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end
@@ -325,7 +325,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
 
-      client.send_inbox_message(req).should eq({ "delivery_id" => 1 })
+      expect(client.send_inbox_message(req)).to eq({ "delivery_id" => 1 })
     end
 
     it "handles validation failures (400)" do
@@ -342,10 +342,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.send_inbox_message(req) }.should(
+      expect { client.send_inbox_message(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -362,10 +362,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.send_inbox_message(req) }.should(
+      expect { client.send_inbox_message(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end
@@ -384,7 +384,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { delivery_id: 1 }.to_json, headers: {})
 
-      client.send_in_app(req).should eq({ "delivery_id" => 1 })
+      expect(client.send_in_app(req)).to eq({ "delivery_id" => 1 })
     end
 
     it "handles validation failures (400)" do
@@ -401,10 +401,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.send_in_app(req) }.should(
+      expect { client.send_in_app(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -421,10 +421,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.send_in_app(req) }.should(
+      expect { client.send_in_app(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end
@@ -442,7 +442,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { trigger_id: "abc123" }.to_json, headers: {})
 
-      client.trigger_broadcast(req).should eq({ "trigger_id" => "abc123" })
+      expect(client.trigger_broadcast(req)).to eq({ "trigger_id" => "abc123" })
     end
 
     it "sends with email list audience" do
@@ -457,7 +457,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { trigger_id: "abc123" }.to_json, headers: {})
 
-      client.trigger_broadcast(req).should eq({ "trigger_id" => "abc123" })
+      expect(client.trigger_broadcast(req)).to eq({ "trigger_id" => "abc123" })
     end
 
     it "sends with id list audience" do
@@ -471,7 +471,7 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { trigger_id: "abc123" }.to_json, headers: {})
 
-      client.trigger_broadcast(req).should eq({ "trigger_id" => "abc123" })
+      expect(client.trigger_broadcast(req)).to eq({ "trigger_id" => "abc123" })
     end
 
     it "sends with data_file_url audience" do
@@ -484,35 +484,35 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 200, body: { trigger_id: "abc123" }.to_json, headers: {})
 
-      client.trigger_broadcast(req).should eq({ "trigger_id" => "abc123" })
+      expect(client.trigger_broadcast(req)).to eq({ "trigger_id" => "abc123" })
     end
 
     it "raises an error when broadcast_id is missing" do
-      lambda {
+      expect {
         Customerio::TriggerBroadcastRequest.new(data: { headline: "Test" })
-      }.should raise_error(ArgumentError, "broadcast_id is required")
+      }.to raise_error(ArgumentError, "broadcast_id is required")
     end
 
     it "raises an error when broadcast_id is not an integer" do
-      lambda {
+      expect {
         Customerio::TriggerBroadcastRequest.new(broadcast_id: "12")
-      }.should raise_error(ArgumentError, "broadcast_id must be an integer")
+      }.to raise_error(ArgumentError, "broadcast_id must be an integer")
     end
 
     it "raises an error when multiple audience fields are provided" do
-      lambda {
+      expect {
         Customerio::TriggerBroadcastRequest.new(
           broadcast_id: 12,
           emails: ["a@example.com"],
           ids: [1, 2],
         )
-      }.should raise_error(ArgumentError, /only one of/)
+      }.to raise_error(ArgumentError, /only one of/)
     end
 
     it "raises an error when request is not a TriggerBroadcastRequest" do
-      lambda {
+      expect {
         client.trigger_broadcast("not a request")
-      }.should raise_error(ArgumentError, /must be an instance of/)
+      }.to raise_error(ArgumentError, /must be an instance of/)
     end
 
     it "handles validation failures (400)" do
@@ -527,10 +527,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 400, body: err_json, headers: {})
 
-      lambda { client.trigger_broadcast(req) }.should(
+      expect { client.trigger_broadcast(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "example error"
-          error.code.should eq "400"
+      expect(    error.message).to eq("example error")
+      expect(    error.code).to eq("400")
         }
       )
     end
@@ -544,10 +544,10 @@ describe Customerio::APIClient do
         .with(headers: request_headers, body: req.message)
         .to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.trigger_broadcast(req) }.should(
+      expect { client.trigger_broadcast(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-          error.message.should eq "Server unavailable"
-          error.code.should eq "500"
+      expect(    error.message).to eq("Server unavailable")
+      expect(    error.code).to eq("500")
         }
       )
     end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -95,8 +95,8 @@ describe Customerio::APIClient do
 
       expect { client.send_email(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -115,8 +115,8 @@ describe Customerio::APIClient do
 
       expect { client.send_email(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end
@@ -202,8 +202,8 @@ describe Customerio::APIClient do
 
       expect { client.send_push(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -222,8 +222,8 @@ describe Customerio::APIClient do
 
       expect { client.send_push(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end
@@ -285,8 +285,8 @@ describe Customerio::APIClient do
 
       expect { client.send_sms(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -305,8 +305,8 @@ describe Customerio::APIClient do
 
       expect { client.send_sms(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end
@@ -344,8 +344,8 @@ describe Customerio::APIClient do
 
       expect { client.send_inbox_message(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -364,8 +364,8 @@ describe Customerio::APIClient do
 
       expect { client.send_inbox_message(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end
@@ -403,8 +403,8 @@ describe Customerio::APIClient do
 
       expect { client.send_in_app(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -423,8 +423,8 @@ describe Customerio::APIClient do
 
       expect { client.send_in_app(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end
@@ -529,8 +529,8 @@ describe Customerio::APIClient do
 
       expect { client.trigger_broadcast(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("example error")
-      expect(    error.code).to eq("400")
+      expect(error.message).to eq("example error")
+      expect(error.code).to eq("400")
         }
       )
     end
@@ -546,8 +546,8 @@ describe Customerio::APIClient do
 
       expect { client.trigger_broadcast(req) }.to(
         raise_error(Customerio::InvalidResponse) { |error|
-      expect(    error.message).to eq("Server unavailable")
-      expect(    error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
+      expect(error.code).to eq("500")
         }
       )
     end

--- a/spec/base_client_spec.rb
+++ b/spec/base_client_spec.rb
@@ -73,7 +73,7 @@ describe Customerio::BaseClient do
         with(headers: api_client_request_headers).
         to_return(status: 400, body: "", headers: {})
 
-      lambda { api_client.request_and_verify_response(:put, '/some/path', "") }.should(
+      expect { api_client.request_and_verify_response(:put, '/some/path', "") }.to(
         raise_error(Customerio::InvalidResponse)
       )
     end
@@ -83,7 +83,7 @@ describe Customerio::BaseClient do
         with(headers: api_client_request_headers).
         to_return(status: 200, body: "Test", headers: {})
 
-      api_client.request_and_verify_response(:put, '/some/path', "").body.should eq("Test")
+      expect(api_client.request_and_verify_response(:put, '/some/path', "").body).to eq("Test")
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -131,7 +131,7 @@ describe Customerio::Client do
         with(body: json(id: 5)).
         to_return(status: 500, body: "", headers: {})
 
-      lambda { client.identify(id: 5) }.should raise_error(Customerio::InvalidResponse)
+      expect { client.identify(id: 5) }.to raise_error(Customerio::InvalidResponse)
     end
 
     it "includes the HTTP response with raised errors" do
@@ -139,10 +139,10 @@ describe Customerio::Client do
         with(body: json(id: 5)).
         to_return(status: 500, body: "Server unavailable", headers: {})
 
-      lambda { client.identify(id: 5) }.should raise_error {|error|
-        error.should be_a Customerio::InvalidResponse
-        error.code.should eq "500"
-        error.message.should eq "Server unavailable"
+      expect { client.identify(id: 5) }.to raise_error {|error|
+      expect(  error).to be_a(Customerio::InvalidResponse)
+      expect(  error.code).to eq("500")
+      expect(  error.message).to eq("Server unavailable")
       }
     end
 
@@ -170,10 +170,10 @@ describe Customerio::Client do
     end
 
     it "requires an id attribute" do
-      lambda { client.identify(email: "customer@example.com") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify(id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify(cio_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
-      lambda { client.identify(customer_id: "") }.should raise_error(Customerio::Client::MissingIdAttributeError)
+      expect { client.identify(email: "customer@example.com") }.to raise_error(Customerio::Client::MissingIdAttributeError)
+      expect { client.identify(id: "") }.to raise_error(Customerio::Client::MissingIdAttributeError)
+      expect { client.identify(cio_id: "") }.to raise_error(Customerio::Client::MissingIdAttributeError)
+      expect { client.identify(customer_id: "") }.to raise_error(Customerio::Client::MissingIdAttributeError)
     end
 
     it 'should not raise errors when attribute keys are strings' do
@@ -183,7 +183,7 @@ describe Customerio::Client do
 
       attributes = { "id" => 5 }
 
-      lambda { client.identify(attributes) }.should_not raise_error()
+      expect { client.identify(attributes) }.not_to raise_error
     end
 
     it 'uses cio_id for customer id, when present, for id updates' do
@@ -271,7 +271,7 @@ describe Customerio::Client do
       stub_request(:put, /track.customer.io/)
         .to_return(status: 200, body: "", headers: {})
 
-      lambda { client.delete(" ") }.should raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
+      expect { client.delete(" ") }.to raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
     end
 
     it "escapes customer IDs" do
@@ -294,7 +294,7 @@ describe Customerio::Client do
       stub_request(:put, /track.customer.io/)
         .to_return(status: 200, body: "", headers: {})
 
-      lambda { client.suppress(" ") }.should raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
+      expect { client.suppress(" ") }.to raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
     end
   end
 
@@ -310,7 +310,7 @@ describe Customerio::Client do
       stub_request(:put, /track.customer.io/)
         .to_return(status: 200, body: "", headers: {})
 
-      lambda { client.suppress(" ") }.should raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
+      expect { client.suppress(" ") }.to raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
     end
   end
 
@@ -330,15 +330,15 @@ describe Customerio::Client do
         with(body: json(name: "purchase", data: {})).
         to_return(status: 500, body: "", headers: {})
 
-      lambda { client.track(5, "purchase") }.should raise_error(Customerio::InvalidResponse)
+      expect { client.track(5, "purchase") }.to raise_error(Customerio::InvalidResponse)
     end
 
     it "throws an error when customer_id or event_name is missing" do
       stub_request(:put, /track.customer.io/)
         .to_return(status: 200, body: "", headers: {})
 
-      lambda { client.track(" ", "test_event") }.should raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
-      lambda { client.track(5, " ") }.should raise_error(Customerio::Client::ParamError, "event_name must be a non-empty string")
+      expect { client.track(" ", "test_event") }.to raise_error(Customerio::Client::ParamError, "customer_id must be a non-empty string")
+      expect { client.track(5, " ") }.to raise_error(Customerio::Client::ParamError, "event_name must be a non-empty string")
     end
 
     it "uses the site_id and api key for basic auth and sends the event name" do
@@ -573,7 +573,7 @@ describe Customerio::Client do
             with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
             to_return(status: 500, body: "", headers: {})
 
-        lambda { client.track_anonymous(anon_id, "purchase") }.should raise_error(Customerio::InvalidResponse)
+        expect { client.track_anonymous(anon_id, "purchase") }.to raise_error(Customerio::InvalidResponse)
       end
 
       it "doesn't pass along anonymous_id if it is blank" do
@@ -597,7 +597,7 @@ describe Customerio::Client do
             with(body: { anonymous_id: anon_id, name: "purchase", data: {} }).
             to_return(status: 500, body: "", headers: {})
 
-        lambda { client.track_anonymous(anon_id, "") }.should raise_error(Customerio::Client::ParamError)
+        expect { client.track_anonymous(anon_id, "") }.to raise_error(Customerio::Client::ParamError)
       end
 
       it "sends an event id for deduplication when provided" do
@@ -627,22 +627,22 @@ describe Customerio::Client do
       stub_request(:put, api_uri('/api/v1/customers/5/devices')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.add_device("", "ios", "myDeviceID") }.should raise_error(Customerio::Client::ParamError)
-       lambda { client.add_device(nil, "ios", "myDeviceID", {last_used: 1561235678}) }.should raise_error(Customerio::Client::ParamError)
+       expect { client.add_device("", "ios", "myDeviceID") }.to raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(nil, "ios", "myDeviceID", {last_used: 1561235678}) }.to raise_error(Customerio::Client::ParamError)
     end
     it "requires a valid token when creating" do
       stub_request(:put, api_uri('/api/v1/customers/5/devices')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.add_device(5, "", "ios") }.should raise_error(Customerio::Client::ParamError)
-       lambda { client.add_device(5, nil, "ios", {last_used: 1561235678}) }.should raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(5, "", "ios") }.to raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(5, nil, "ios", {last_used: 1561235678}) }.to raise_error(Customerio::Client::ParamError)
     end
     it "requires a valid platform when creating" do
       stub_request(:put, api_uri('/api/v1/customers/5/devices')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.add_device(5, "token", "") }.should raise_error(Customerio::Client::ParamError)
-       lambda { client.add_device(5, "toke", nil, {last_used: 1561235678}) }.should raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(5, "token", "") }.to raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(5, "toke", nil, {last_used: 1561235678}) }.to raise_error(Customerio::Client::ParamError)
     end
     it "accepts a nil data param" do
       stub_request(:put, api_uri('/api/v1/customers/5/devices')).
@@ -654,7 +654,7 @@ describe Customerio::Client do
       stub_request(:put, api_uri('/api/v1/customers/5/devices')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.add_device(5, "ios", "myDeviceID", 1000) }.should raise_error(Customerio::Client::ParamError)
+       expect { client.add_device(5, "ios", "myDeviceID", 1000) }.to raise_error(Customerio::Client::ParamError)
     end
     it "supports deletion of devices by token" do
       stub_request(:delete, api_uri('/api/v1/customers/5/devices/myDeviceID')).
@@ -666,15 +666,15 @@ describe Customerio::Client do
       stub_request(:delete, api_uri('/api/v1/customers/5/devices/myDeviceID')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.delete_device("", "myDeviceID") }.should raise_error(Customerio::Client::ParamError)
-       lambda { client.delete_device(nil, "myDeviceID") }.should raise_error(Customerio::Client::ParamError)
+       expect { client.delete_device("", "myDeviceID") }.to raise_error(Customerio::Client::ParamError)
+       expect { client.delete_device(nil, "myDeviceID") }.to raise_error(Customerio::Client::ParamError)
     end
     it "requires a valid device_id when deleting" do
       stub_request(:delete, api_uri('/api/v1/customers/5/devices/myDeviceID')).
         to_return(status: 200, body: "", headers: {})
 
-       lambda { client.delete_device(5, "") }.should raise_error(Customerio::Client::ParamError)
-       lambda { client.delete_device(5, nil) }.should raise_error(Customerio::Client::ParamError)
+       expect { client.delete_device(5, "") }.to raise_error(Customerio::Client::ParamError)
+       expect { client.delete_device(5, nil) }.to raise_error(Customerio::Client::ParamError)
     end
   end
 
@@ -1000,11 +1000,11 @@ describe Customerio::Client do
     end
 
     it "raises an error when operations is empty" do
-      lambda { client.batch([]) }.should raise_error(Customerio::Client::ParamError)
+      expect { client.batch([]) }.to raise_error(Customerio::Client::ParamError)
     end
 
     it "raises an error when operations is not an array" do
-      lambda { client.batch("not an array") }.should raise_error(Customerio::Client::ParamError)
+      expect { client.batch("not an array") }.to raise_error(Customerio::Client::ParamError)
     end
 
     it "raises an error on non-2xx response" do
@@ -1021,7 +1021,7 @@ describe Customerio::Client do
         with(body: json({ batch: operations })).
         to_return(status: 400, body: "Bad request", headers: {})
 
-      lambda { client.batch(operations) }.should raise_error(Customerio::InvalidResponse)
+      expect { client.batch(operations) }.to raise_error(Customerio::InvalidResponse)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -140,9 +140,9 @@ describe Customerio::Client do
         to_return(status: 500, body: "Server unavailable", headers: {})
 
       expect { client.identify(id: 5) }.to raise_error {|error|
-      expect(  error).to be_a(Customerio::InvalidResponse)
-      expect(  error.code).to eq("500")
-      expect(  error.message).to eq("Server unavailable")
+      expect(error).to be_a(Customerio::InvalidResponse)
+      expect(error.code).to eq("500")
+      expect(error.message).to eq("Server unavailable")
       }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,6 @@ require 'rspec'
 require 'webmock/rspec'
 
 RSpec.configure do |config|
-  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
-  config.mock_with(:rspec) { |c| c.syntax = [:should, :expect] }
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
+  config.mock_with(:rspec) { |c| c.syntax = :expect }
 end


### PR DESCRIPTION
## Summary
- Converted all `.should` / `.should_not` calls to `expect().to` / `expect().not_to` across all spec files
- Restricted `spec_helper.rb` to `:expect` syntax only (removed `:should`)
- No test logic changes — pure syntax modernization

## Test plan
- [x] All 130 examples pass
- [x] Zero `.should` occurrences remain in spec files
- [x] RuboCop clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-suite assertion syntax and RSpec configuration, with no production code or API behavior modified.
> 
> **Overview**
> Updates specs to use `expect(...).to`/`not_to` exclusively, replacing all legacy `.should`/`.should_not` assertions across `api_client_spec`, `base_client_spec`, and `client_spec`.
> 
> Tightens `spec_helper.rb` to enforce **expect-only** syntax for both expectations and mocks, preventing future `should`-style assertions from being added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a2862fa0217bf807421f96bae3af45a316e48e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->