### PR TITLE
Housekeeping: gemspec description, push request device dupe, dead test option

### DIFF
--- a/customerio.gemspec
+++ b/customerio.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/customerio/version"
 Gem::Specification.new do |gem|
   gem.authors = ["John Allison"]
   gem.email = ["john@customer.io"]
-  gem.description = "A ruby client for the Customer.io event API."
-  gem.summary = "A ruby client for the Customer.io event API."
+  gem.description = "A ruby client for the Customer.io Journeys Track API and Transactional API."
+  gem.summary = "A ruby client for the Customer.io Journeys Track API and Transactional API."
   gem.homepage = "https://customer.io"
   gem.license = "MIT"
 

--- a/lib/customerio/requests/send_push_request.rb
+++ b/lib/customerio/requests/send_push_request.rb
@@ -18,7 +18,6 @@ module Customerio
       link
       sound
       custom_data
-      device
       custom_device
     ].freeze
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -115,7 +115,7 @@ describe Customerio::Client do
     end
 
     it "sends a PUT request to customer.io's customer API using json headers" do
-      client = Customerio::Client.new("SITE_ID", "API_KEY", json: true)
+      client = Customerio::Client.new("SITE_ID", "API_KEY")
       body = { id: 5, name: "Bob" }
 
       stub_request(:put, api_uri('/api/v1/customers/5')).
@@ -390,7 +390,7 @@ describe Customerio::Client do
     end
 
     it "sends a POST request as json using json headers" do
-      client = Customerio::Client.new("SITE_ID", "API_KEY", json: true)
+      client = Customerio::Client.new("SITE_ID", "API_KEY")
       data = { type: "socks", price: "13.99" }
       body = { name: "purchase", data: data }
 
@@ -682,7 +682,7 @@ describe Customerio::Client do
     attr_accessor :client, :attributes
 
     before(:each) do
-      @client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
+      @client = Customerio::Client.new("SITE_ID", "API_KEY")
       @attributes = {
         :delivery_id => 'foo',
         :device_id => 'bar',
@@ -761,7 +761,7 @@ describe Customerio::Client do
     attr_accessor :client, :attributes
 
     before(:each) do
-      @client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
+      @client = Customerio::Client.new("SITE_ID", "API_KEY")
       @attributes = {
         :delivery_id => "abc123"
       }
@@ -923,7 +923,7 @@ describe Customerio::Client do
 
   describe "#merge_customers" do
     before(:each) do
-      @client = Customerio::Client.new("SITE_ID", "API_KEY", :json => true)
+      @client = Customerio::Client.new("SITE_ID", "API_KEY")
     end
 
     it "should raise validation errors on merge params" do


### PR DESCRIPTION
## Summary
- Updated gemspec description/summary to mention both Track and Transactional APIs (was just "event API")
- Removed `device` from `SendPushRequest::OPTIONAL_FIELDS` — it was already mapped to `custom_device` manually, causing both keys to appear in the message
- Removed no-op `json: true` option from 5 test `Client.new` calls (JSON is always the encoding)

## Test plan
- [x] All 130 examples pass
- [x] RuboCop clean
- [x] `.gitignore` already had `pkg` entry — no change needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk housekeeping changes: updates gem metadata text, removes a duplicated push payload field, and simplifies specs by dropping an unused `json: true` option without altering core request behavior.
> 
> **Overview**
> Updates the gemspec `description`/`summary` to describe support for the Journeys Track and Transactional APIs (instead of only the event API).
> 
> Fixes `SendPushRequest` payload construction by removing `device` from `OPTIONAL_FIELDS` and only mapping `opts[:device]` into `custom_device`, avoiding both keys being sent.
> 
> Cleans up specs by removing the no-op `json: true` option from several `Customerio::Client.new` calls now that JSON encoding is the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9ca23c77737b92feb97caf58bcdb8003637762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->