### PR TITLE
Fix remaining should syntax in timestamp specs

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -434,21 +434,21 @@ describe Customerio::Client do
     end
 
     it "raises an error if timestamp is in milliseconds" do
-      lambda {
+      expect {
         client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: 1561231234000)
-      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
+      }.to raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "raises an error if timestamp is a date" do
-      lambda {
+      expect {
         client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: Time.now)
-      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
+      }.to raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "raises an error if timestamp isn't an integer" do
-      lambda {
+      expect {
         client.track(5, "purchase", {type: "socks", price: "13.99"}, timestamp: "Hello world")
-      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
+      }.to raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "sends an event id for deduplication when provided" do
@@ -819,12 +819,12 @@ describe Customerio::Client do
     end
 
     it "raises an error when timestamp is not a valid integer" do
-      lambda {
+      expect {
         client.track_delivery_metric("delivered", {
           :delivery_id => "abc123",
           :timestamp => "not-a-timestamp"
         })
-      }.should raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
+      }.to raise_error(Customerio::Client::ParamError, /timestamp must be a valid integer/)
     end
 
     it "should raise if metric_name is invalid" do


### PR DESCRIPTION
## Summary
- Convert 4 remaining `lambda { }.should raise_error` calls to `expect { }.to raise_error` in timestamp validation specs
- These were missed in #146 and fail on modern RSpec

## Test plan
- [ ] CI passes all specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to RSpec expectation syntax in specs and do not affect runtime code paths.
> 
> **Overview**
> Updates timestamp validation specs in `spec/client_spec.rb` to use modern RSpec `expect { ... }.to raise_error` syntax instead of deprecated `lambda { ... }.should raise_error`, fixing compatibility with current RSpec versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00f582238ec23117eb65392514f2978ae1ad376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->