### PR TITLE
Bump version to 6.1.0

### DIFF
--- a/lib/customerio/version.rb
+++ b/lib/customerio/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Customerio
-  VERSION = "6.0.0"
+  VERSION = "6.1.0"
 end


### PR DESCRIPTION
## Summary
- Bump `Customerio::VERSION` from 6.0.0 to 6.1.0 to match the v6.1.0 tag

## Test plan
- [ ] Verify `lib/customerio/version.rb` reads `6.1.0`
- [ ] Confirm gem builds cleanly with `gem build customerio.gemspec`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no functional code modifications; risk is limited to release/packaging workflows that depend on the gem version string.
> 
> **Overview**
> Bumps `Customerio::VERSION` from `6.0.0` to `6.1.0` to align the gem’s version constant with the new release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f572b55b67b0544b405cd86f58d0a978161a95bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->