### PR TITLE
Auto-bump version.rb from release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,14 +24,22 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Verify tag matches gem version
+      - name: Set gem version from tag
         run: |
           tag="${GITHUB_REF#refs/tags/v}"
-          version=$(ruby -r ./lib/customerio/version -e "puts Customerio::VERSION")
-          if [ "$tag" != "$version" ]; then
-            echo "::error::Tag v$tag does not match Customerio::VERSION ($version)"
-            exit 1
-          fi
+          sed -i "s/VERSION = \".*\"/VERSION = \"$tag\"/" lib/customerio/version.rb
+          echo "Version set to $tag"
 
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1
+
+      - name: Update version on main
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          sed -i "s/VERSION = \".*\"/VERSION = \"$tag\"/" lib/customerio/version.rb
+          git add lib/customerio/version.rb
+          git commit -m "Bump version to $tag [skip ci]"
+          git push origin main


### PR DESCRIPTION
## Summary
- Replace manual version verification with automatic version injection from git tag
- After publishing to RubyGems, commit the version bump back to main
- No more manual version bump PRs — just cut a GitHub Release and everything flows

## How it works
1. Create a GitHub Release with tag `vX.Y.Z`
2. Workflow sets `VERSION = "X.Y.Z"` in `version.rb` before `gem build`
3. Publishes to RubyGems
4. Commits the version bump back to `main`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Cut a test release to confirm end-to-end flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow to rewrite `lib/customerio/version.rb` from the pushed tag and then push a commit to `main`, which can fail or cause unintended version bumps if tags/permissions are misconfigured.
> 
> **Overview**
> Release workflow now **derives the gem version from the pushed `v*` tag** by editing `lib/customerio/version.rb` before publishing, replacing the previous tag-to-version verification step.
> 
> After publishing, it **checks out `main` and commits/pushes the same version bump back to the repository**, automating the post-release version update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d62d6703b9e44bf742dcc71422101e3cd0fe1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->